### PR TITLE
docs: review and fix AI-readable documentation files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,6 @@
 # AGENTS.md
 
-> A living reference for both **human contributors** and **AI coding agents** (GitHub Copilot,
-> Cursor, Claude, Gemini, etc.) working on the Opportune codebase. It covers build commands,
-> code conventions, project structure, and the AI feature architecture — everything needed to
-> contribute effectively without reading every source file first.
+> A living reference for both **human contributors** and **AI coding agents** (GitHub Copilot, Cursor, Claude, Gemini, etc.) working on the Opportune codebase. It covers build commands, code conventions, project structure, and the AI feature architecture — everything needed to contribute effectively without reading every source file first.
 
 ---
 
@@ -29,8 +26,7 @@
 
 ## 1. Project Overview
 
-**Opportune** is a full-stack application that helps users craft tailored resumes and cover
-letters and track their job-search activity — all augmented by AI.
+**Opportune** is a full-stack application that helps users craft tailored resumes and cover letters and track their job-search activity — all augmented by AI.
 
 | Layer    | Technology                                                               |
 | -------- | ------------------------------------------------------------------------ |
@@ -40,8 +36,7 @@ letters and track their job-search activity — all augmented by AI.
 | Build    | Gradle (Kotlin DSL) with `node-gradle` plugin for the frontend           |
 | Auth     | JWT-based (Spring Security OAuth2 Resource Server) — stateless sessions  |
 
-The AI layer is deliberately centralised in the backend so that the frontend never holds
-API keys or model parameters.
+The AI layer is deliberately centralised in the backend so that the frontend never holds API keys or model parameters.
 
 ---
 
@@ -79,6 +74,8 @@ npm run format
 
 ## 3. Environment Setup
 
+> See [`DEVELOPMENT.md`](./DEVELOPMENT.md) for the complete local setup guide.
+
 ### Prerequisites
 
 | Tool       | Version                                                           |
@@ -89,8 +86,7 @@ npm run format
 
 ### Environment files
 
-The Gradle `bootRun` task loads variables from `.env.<profile>` files automatically.
-Copy the example and fill in required values:
+The Gradle `bootRun` task loads variables from `.env.<profile>` files automatically. Copy the example and fill in required values:
 
 ```bash
 cp .env.dev.example .env.dev   # adjust values as needed
@@ -121,35 +117,103 @@ The application itself is run via Gradle, not Docker, during development.
 
 ```
 opportune/
+├── .github/                         # GitHub workflows and templates
+├── bin/                             # Build/run helper scripts
+├── cypress/                         # E2E tests (Cypress)
+│   └── e2e/
+├── docs/                            # Additional documentation
+├── gradle/                          # Gradle wrapper
 ├── src/
 │   ├── main/
 │   │   ├── kotlin/com/glinboy/opportune/
-│   │   │   ├── aop/          # Cross-cutting concerns (logging, auditing aspects)
-│   │   │   ├── config/       # Spring configuration beans (Security, Jackson, OpenAPI, etc.)
-│   │   │   ├── dto/          # Data Transfer Objects (request/response shapes)
-│   │   │   ├── entity/       # JPA entities
-│   │   │   ├── enums/        # Shared enumerations (Role, ApplicationStatus, etc.)
-│   │   │   ├── event/        # Spring application events (e.g. ApplicationSubmittedEvent)
-│   │   │   ├── mapper/       # MapStruct mappers (entity ↔ DTO)
-│   │   │   ├── projection/   # JPA interface projections for lightweight queries
-│   │   │   ├── repository/   # Spring Data JPA repositories
-│   │   │   ├── security/     # JWT utilities, SecurityUtils, auth converters
-│   │   │   ├── service/      # Business logic (interfaces + impl/ sub-package)
-│   │   │   ├── util/         # Shared utilities
-│   │   │   └── web/          # REST controllers, filters, exception handlers
+│   │   │   ├── aop/
+│   │   │   │   ├── logging/         # Logging aspects
+│   │   │   │   └── session/         # Session tracking aspects
+│   │   │   ├── config/              # Spring configuration beans (Security, Jackson, OpenAPI, etc.)
+│   │   │   ├── dto/                 # Data Transfer Objects (request/response shapes)
+│   │   │   ├── entity/              # JPA entities
+│   │   │   ├── enums/               # Shared enumerations (Role, ApplicationStatus, etc.)
+│   │   │   ├── event/               # Spring application events (e.g. ApplicationSubmittedEvent)
+│   │   │   ├── mapper/              # MapStruct mappers (entity ↔ DTO)
+│   │   │   ├── projection/          # JPA interface projections for lightweight queries
+│   │   │   ├── repository/          # Spring Data JPA repositories
+│   │   │   ├── security/
+│   │   │   │   └── jwt/             # JWT utilities, SecurityUtils, auth converters
+│   │   │   ├── service/
+│   │   │   │   └── impl/            # Business logic implementations
+│   │   │   ├── util/                # Shared utilities
+│   │   │   └── web/
+│   │   │       ├── controller/      # REST controllers
+│   │   │       ├── filter/          # Servlet filters
+│   │   │       └── rest/            # REST exception handlers / advice
 │   │   ├── resources/
-│   │   │   ├── config/       # application.yml, profile overrides
-│   │   │   ├── db/migration/ # Flyway SQL migration scripts
-│   │   │   ├── prompts/      # Spring AI prompt templates (.st files)
-│   │   │   └── templates/    # Thymeleaf email templates
-│   │   └── webapp/           # Vue 3 frontend source (TypeScript + Vuetify)
+│   │   │   ├── config/              # application.yml, profile overrides
+│   │   │   ├── db/migration/
+│   │   │   │   └── h2/              # Flyway SQL migration scripts (H2 compat)
+│   │   │   ├── prompts/             # Spring AI prompt templates (.st files)
+│   │   │   └── templates/
+│   │   │       └── mail/            # Thymeleaf email templates
+│   │   └── webapp/                  # Vue 3 + TypeScript + Vuetify frontend
+│   │       ├── public/
+│   │       └── src/
+│   │           ├── assets/
+│   │           │   └── images/
+│   │           ├── components/       # Reusable UI components
+│   │           │   ├── __tests__/
+│   │           │   ├── admin/dashboard/
+│   │           │   ├── app-bar/
+│   │           │   ├── application/
+│   │           │   ├── company/
+│   │           │   ├── dashboard/
+│   │           │   ├── forms/
+│   │           │   ├── icons/
+│   │           │   ├── markdown/
+│   │           │   ├── profile/
+│   │           │   └── profile-menu/
+│   │           ├── composables/      # Shared reactive logic (useXxx pattern)
+│   │           ├── layouts/          # Page layout shells
+│   │           ├── models/
+│   │           │   └── enumerations/
+│   │           ├── plugins/          # Vuetify plugin config
+│   │           ├── router/           # Vue Router routes
+│   │           ├── services/
+│   │           │   └── admin/
+│   │           ├── stores/           # Pinia stores
+│   │           ├── utils/            # Pure helper functions
+│   │           └── views/            # Page-level route components
+│   │               ├── admin/
+│   │               ├── application/
+│   │               ├── auth/
+│   │               ├── company/
+│   │               └── profile/
 │   └── test/
-│       └── kotlin/           # Mirrors main package layout; test profile uses H2
-├── build.gradle.kts           # Single Gradle build file (backend + frontend tasks)
-├── Makefile                   # Convenience targets: start, stop, restart, status
-├── compose.yaml               # Docker Compose for backing services (PostgreSQL, etc.)
-├── Dockerfile                 # Multi-stage image: builder (JDK 24) → runner (JRE alpine)
-└── AGENTS.md                  # This file
+│       ├── kotlin/com/glinboy/opportune/
+│       │   └── service/
+│       │       └── impl/             # Mirror of main package layout
+│       └── resources/
+│           └── config/              # Test profile config (application-test.yml)
+├── build.gradle.kts                  # Single Gradle build (backend + frontend tasks)
+├── settings.gradle.kts               # Gradle project settings
+├── compose.yaml                      # Docker Compose for backing services
+├── Dockerfile                        # Multi-stage: builder (JDK 24) → runner (JRE alpine)
+├── Makefile                          # Convenience targets: start, stop, restart, status
+├── package.json                      # Frontend npm dependencies and scripts
+├── package-lock.json
+├── vite.config.ts                    # Vite build config with API proxy
+├── vitest.config.ts                  # Vitest frontend test config
+├── cypress.config.ts                 # Cypress E2E test config
+├── tsconfig.json                     # TypeScript base config
+├── tsconfig.app.json                 # TypeScript app config
+├── tsconfig.node.json                # TypeScript Node config
+├── tsconfig.vitest.json              # TypeScript Vitest config
+├── env.d.ts                          # Vite env type declarations
+├── eslint.config.ts                  # ESLint config
+├── .prettierrc.json                  # Prettier config
+├── .editorconfig                     # Editor config
+├── .env.example                      # Environment variables template
+├── .gitignore
+├── .gitattributes
+└── AGENTS.md                         # This file
 ```
 
 **Key paths for AI work:**
@@ -214,6 +278,8 @@ make status     # show running/stopped services
 
 ## 6. Testing
 
+> See [`TESTING.md`](./TESTING.md) for the full testing strategy and conventions.
+
 ### Backend unit & integration tests
 
 ```bash
@@ -255,19 +321,14 @@ npm run test:e2e
 
 ### Kotlin (backend)
 
-- **Kotlin 2.x** with `-Xjsr305=strict` — treat Spring's `@Nullable` / `@NonNull` annotations
-  as Kotlin nullability.
+- **Kotlin 2.x** with `-Xjsr305=strict` — treat Spring's `@Nullable` / `@NonNull` annotations as Kotlin nullability.
 - **No `var` in DTOs or entities** — prefer `val` and immutable data classes.
 - **Data classes for DTOs** — use Kotlin `copy()` for updates instead of mutation.
 - **`@Transactional` at service layer** — never on repository or controller methods.
-- **JSON naming:** Jackson is configured with `PropertyNamingStrategies.SNAKE_CASE`.
-  All API fields use `snake_case` (e.g. `profile_id`, `created_date`).
-- **Logging:** Use `LoggerFactory.getLogger(this::class.java)` — never log prompt content
-  at `INFO` or above (privacy constraint).
-- **Security:** Always scope queries to the authenticated user via `SecurityUtils.getCurrentUserLoginID()`.
-  Never return data across user boundaries.
-- **JPA entities** annotated with `@Entity` / `@MappedSuperclass` must remain `open`
-  (enforced by `allOpen` Gradle plugin).
+- **JSON naming:** Jackson is configured with `PropertyNamingStrategies.SNAKE_CASE`. All API fields use `snake_case` (e.g. `profile_id`, `created_date`).
+- **Logging:** Use `LoggerFactory.getLogger(this::class.java)` — never log prompt content at `INFO` or above (privacy constraint).
+- **Security:** Always scope queries to the authenticated user via `SecurityUtils.getCurrentUserLoginID()`. Never return data across user boundaries.
+- **JPA entities** annotated with `@Entity` / `@MappedSuperclass` must remain `open` (enforced by `allOpen` Gradle plugin).
 
 ### Vue 3 / TypeScript (frontend)
 
@@ -297,17 +358,13 @@ npm run test:e2e
 | Streaming               | Spring AI `Flux<String>` / Server-Sent Events                       | For long-form generation                     |
 | Document pre-processing | `pdfbox` (PDF), `jsoup` (HTML)                                      | Raw text extracted before LLM call           |
 
-> **Provider abstraction:** Swapping OpenAI for another provider (Anthropic, Ollama, etc.)
-> requires only a configuration change — no code change — unless the feature uses
-> provider-specific response formats.
+> **Provider abstraction:** Swapping OpenAI for another provider (Anthropic, Ollama, etc.) requires only a configuration change — no code change — unless the feature uses provider-specific response formats.
 
 ---
 
 ## 9. Agent Catalogue
 
-Each _agent_ here is a distinct AI interaction with its own purpose, system prompt, and
-input/output contract. They are request-scoped Spring service methods — not long-running
-autonomous processes.
+Each _agent_ here is a distinct AI interaction with its own purpose, system prompt, and input/output contract. They are request-scoped Spring service methods — not long-running autonomous processes.
 
 **Implementation status legend:** ✅ Implemented · 🔲 Planned
 
@@ -323,9 +380,7 @@ autonomous processes.
 | **Service**      | `AiServiceImpl.analysisApplication()`                                                                                                       |
 | **Prompt files** | `src/main/resources/prompts/ai-analysis-system.st` (system), `ai-analysis-user.st` (user)                                                   |
 
-> **JSON safety:** The system prompt includes explicit escaping rules because the output
-> schema contains curly braces. The service strips any accidental ` ```json ` fences from
-> the response before parsing.
+> **JSON safety:** The system prompt includes explicit escaping rules because the output schema contains curly braces. The service strips any accidental ` ```json ` fences from the response before parsing.
 
 ### 9.2 Resume Builder Agent 🔲
 
@@ -375,6 +430,8 @@ autonomous processes.
 
 ## 10. Prompt Architecture
 
+> See [`PROMPTS.md`](./PROMPTS.md) for the complete prompt system documentation — template syntax, input/output contracts, update workflow, and testing procedures.
+
 ### Directory layout
 
 ```
@@ -387,13 +444,9 @@ src/main/resources/prompts/
 └── job-description-analyser.st # Job Description Analyser Agent  [planned]
 ```
 
-Spring AI's `PromptTemplate` loads `.st` files from the classpath. Placeholder variables
-use `{variableName}` syntax.
+Spring AI's `PromptTemplate` loads `.st` files from the classpath. Placeholder variables use `{variableName}` syntax.
 
-> **Gotcha for JSON-heavy prompts:** If the system prompt embeds a JSON schema with curly
-> braces, `PromptTemplate` may misparse them as variable placeholders. In that case, load
-> the file as raw text and perform string substitution manually (see `AiServiceImpl` for the
-> pattern).
+> **Gotcha for JSON-heavy prompts:** If the system prompt embeds a JSON schema with curly braces, `PromptTemplate` may misparse them as variable placeholders. In that case, load the file as raw text and perform string substitution manually (see `AiServiceImpl` for the pattern).
 
 ### Prompt file structure
 
@@ -407,10 +460,8 @@ Template with {variable} placeholders filled at runtime.
 
 ### Prompt authoring principles
 
-- **Be explicit about output format.** Markdown output? Say so. JSON output? Provide the
-  full schema with field names and types.
-- **Include a safety line.** Every prompt must contain:
-  _"Do not invent information. If a field cannot be determined, leave it blank."_
+- **Be explicit about output format.** Markdown output? Say so. JSON output? Provide the full schema with field names and types.
+- **Include a safety line.** Every prompt must contain: _"Do not invent information. If a field cannot be determined, leave it blank."_
 - **Wrap user-supplied text in delimiters** to defend against prompt injection:
   ```
   ---BEGIN USER TEXT---
@@ -458,18 +509,16 @@ Vue 3 component (md-editor-v3 / marked renderer)
 
 **Key points:**
 
-- AI has no dedicated API endpoints. Processing is triggered asynchronously via
-  `ApplicationSubmittedEvent` — the user's HTTP request is not blocked.
-- All `/api/**` endpoints require authentication. Spring Security rejects unauthenticated
-  requests before they reach the controller layer.
-- User-uploaded documents are **never sent verbatim** to the model — only the plain text
-  extracted by `pdfbox` / `jsoup`.
-- The frontend polls `GET /api/applications/{id}/details` to retrieve AI-generated fields
-  once processing completes.
+- AI has no dedicated API endpoints. Processing is triggered asynchronously via `ApplicationSubmittedEvent` — the user's HTTP request is not blocked.
+- All `/api/**` endpoints require authentication. Spring Security rejects unauthenticated requests before they reach the controller layer.
+- User-uploaded documents are **never sent verbatim** to the model — only the plain text extracted by `pdfbox` / `jsoup`.
+- The frontend polls `GET /api/applications/{id}/details` to retrieve AI-generated fields once processing completes.
 
 ---
 
 ## 12. Security & Privacy Constraints
+
+> See [`SECURITY.md`](./SECURITY.md) for the full authentication and authorization model.
 
 | Constraint                   | Implementation                                                                                                                              |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -484,8 +533,7 @@ Vue 3 component (md-editor-v3 / marked renderer)
 
 ## 13. Configuration Reference
 
-All AI configuration lives in `src/main/resources/config/application.yml` and
-profile-specific overrides (`application-dev.yml`, `application-prod.yml`).
+All AI configuration lives in `src/main/resources/config/application.yml` and profile-specific overrides (`application-dev.yml`, `application-prod.yml`).
 
 ```yaml
 # application.yml (excerpt — do not paste real keys here)
@@ -518,15 +566,10 @@ Profile env files (`.env.dev`, `.env.prod`) are loaded automatically by the Grad
 Follow these steps when adding or extending an AI agent:
 
 1. **Add a prompt file** in `src/main/resources/prompts/` following the structure in §10.
-2. **Create or extend an AI service** in `service/impl/`, injecting `ChatClient`
-   (or `StreamingChatClient` for SSE responses).
-3. **Expose a controller endpoint** under `/api/...` following existing API path
-   conventions — secured by default via Spring Security (no extra configuration needed for
-   standard `/api/**` paths). For event-driven agents, the endpoint is the entry point
-   that triggers the async flow (see §11) rather than a direct AI call.
+2. **Create or extend an AI service** in `service/impl/`, injecting `ChatClient` (or `StreamingChatClient` for SSE responses).
+3. **Expose a controller endpoint** under `/api/...` following existing API path conventions — secured by default via Spring Security (no extra configuration needed for standard `/api/**` paths). For event-driven agents, the endpoint is the entry point that triggers the async flow (see §11) rather than a direct AI call.
 4. **Document the agent** in §9 of this file and update its status from 🔲 to ✅.
-5. **Write a unit test** that mocks `ChatClient` and asserts prompt variable injection —
-   never assert on LLM output content.
+5. **Write a unit test** that mocks `ChatClient` and asserts prompt variable injection — never assert on LLM output content.
 6. **Run the full test suite** before submitting: `./gradlew test -Pprofile=test`.
 
 ---

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -284,16 +284,16 @@ Avoid these common mistakes:
 
 Use this quick map:
 
-- AI behavior changed -> update `AGENTS.md`
-- structural layering changed -> update `ARCHITECTURE.md`
-- design or UI conventions changed -> update `DESIGN.md`
-- local setup/workflow changed -> update `DEVELOPMENT.md`
-- contribution process changed -> update `CONTRIBUTING.md`
-- API contract changed -> update `API.md`
-- security model changed -> update `SECURITY.md`
-- data model or entities changed -> update `DATA_MODEL.md`
-- prompt templates changed -> update `PROMPTS.md`
-- test strategy changed -> update `TESTING.md`
+- AI behavior changed → update [`AGENTS.md`](./AGENTS.md)
+- structural layering changed → update [`ARCHITECTURE.md`](./ARCHITECTURE.md)
+- design or UI conventions changed → update [`DESIGN.md`](./DESIGN.md)
+- local setup/workflow changed → update [`DEVELOPMENT.md`](./DEVELOPMENT.md)
+- contribution process changed → update [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+- API contract changed → update [`API.md`](./API.md)
+- security model changed → update [`SECURITY.md`](./SECURITY.md)
+- data model or entities changed → update [`DATA_MODEL.md`](./DATA_MODEL.md)
+- prompt templates changed → update [`PROMPTS.md`](./PROMPTS.md)
+- test strategy changed → update [`TESTING.md`](./TESTING.md)
 
 This file should stay short and high-signal. Put deeper detail in the specialized docs.
 
@@ -303,16 +303,16 @@ This file should stay short and high-signal. Put deeper detail in the specialize
 
 Read these together:
 
-- `AGENTS.md`
-- `DESIGN.md`
-- `ARCHITECTURE.md`
-- `CONTRIBUTING.md`
-- `DEVELOPMENT.md`
-- `API.md`
-- `DATA_MODEL.md`
-- `SECURITY.md`
-- `PROMPTS.md`
-- `TESTING.md`
+- [`AGENTS.md`](./AGENTS.md)
+- [`DESIGN.md`](./DESIGN.md)
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md)
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+- [`DEVELOPMENT.md`](./DEVELOPMENT.md)
+- [`API.md`](./API.md)
+- [`DATA_MODEL.md`](./DATA_MODEL.md)
+- [`SECURITY.md`](./SECURITY.md)
+- [`PROMPTS.md`](./PROMPTS.md)
+- [`TESTING.md`](./TESTING.md)
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -80,18 +80,26 @@ A simplified layout looks like this:
 ```text
 opportune/
 ├── build.gradle.kts
+├── settings.gradle.kts
 ├── package.json
+├── compose.yaml
+├── Dockerfile
+├── Makefile
+├── docs/
 ├── AGENTS.md
 ├── DESIGN.md
 ├── ARCHITECTURE.md
 ├── CONTRIBUTING.md
 ├── DEVELOPMENT.md
 └── src/
-    └── main/
-        ├── kotlin/
-        ├── resources/
-        └── webapp/
-            └── src/
+    ├── main/
+    │   ├── kotlin/          → Backend source (Kotlin + Spring Boot)
+    │   ├── resources/       → config/, db/migration/, prompts/, templates/
+    │   └── webapp/          → Frontend source (Vue 3 + Vite)
+    │       └── src/
+    └── test/
+        ├── kotlin/          → Backend tests (JUnit 5)
+        └── resources/       → Test config (application-test.yml)
 ```
 
 The frontend source folders are `assets`, `components`, `composables`, `layouts`, `models`, `plugins`, `router`, `services`, `stores`, `utils`, and `views` under `src/main/webapp/src/`.
@@ -119,22 +127,26 @@ The actual package layout is:
 
 ```text
 src/main/kotlin/.../opportune/
-├── aop/             # Cross-cutting concerns (logging, auditing aspects)
-├── config/          # Spring configuration beans (Security, Jackson, OpenAPI, etc.)
-├── dto/             # Data Transfer Objects (request/response shapes)
-├── entity/          # JPA entities
-├── enums/           # Shared enumerations (Role, ApplicationStatus, etc.)
-├── event/           # Spring application events (e.g. ApplicationSubmittedEvent)
-├── mapper/          # MapStruct mappers (entity ↔ DTO)
-├── projection/      # JPA interface projections for lightweight queries
-├── repository/      # Spring Data JPA repositories
-├── security/        # JWT utilities, SecurityUtils, auth converters
-├── service/         # Business logic and orchestration (interfaces + impl/ sub-package)
-├── util/            # Shared utilities
-└── web/             # REST controllers, filters, exception handlers
-    ├── controller/
-    ├── filter/
-    └── rest/
+├── aop/
+│   ├── logging/         # Logging aspects
+│   └── session/         # Session tracking aspects
+├── config/              # Spring configuration beans (Security, Jackson, OpenAPI, etc.)
+├── dto/                 # Data Transfer Objects (request/response shapes)
+├── entity/              # JPA entities
+├── enums/               # Shared enumerations (Role, ApplicationStatus, etc.)
+├── event/               # Spring application events (e.g. ApplicationSubmittedEvent)
+├── mapper/              # MapStruct mappers (entity ↔ DTO)
+├── projection/          # JPA interface projections for lightweight queries
+├── repository/          # Spring Data JPA repositories
+├── security/
+│   └── jwt/             # JWT utilities, SecurityUtils, auth converters
+├── service/
+│   └── impl/            # Business logic and orchestration
+├── util/                # Shared utilities
+└── web/
+    ├── controller/      # REST controllers
+    ├── filter/          # Servlet filters
+    └── rest/            # REST exception handlers / advice
 ```
 
 AI service logic lives in `service/` — there is no separate `ai/` package. Keep new backend code in the most specific existing package that matches its responsibility.
@@ -255,57 +267,33 @@ If a view grows too much, split it before continuing to add logic.
 
 ## UI Architecture
 
+The UI architecture is built on three layers — see [`DESIGN.md §5`](./DESIGN.md) for the full design language and tokens.
+
 ### Component strategy
 
-The UI component layer should be built with Vuetify components, while the visual language should follow a Tabler-inspired style system applied through shared overrides rather than bypassing Vuetify.
-
-This means:
-
-- use Vuetify as the component foundation
-- style globally through shared overrides where appropriate
-- avoid replacing Vuetify components with raw HTML just to imitate Tabler
-
-### Global style architecture
-
-`src/main/webapp/src/assets/tabler-overrides.scss` contains global visual overrides for cards, buttons, fields, drawers, tables, dividers, elevations, app bars, list items, typography, touch targets, tooltips, images, and chart wrappers.
-
-Use style locations deliberately:
-
-- local component styles -> inside the component
-- global Vuetify visual overrides -> `src/main/webapp/src/assets/tabler-overrides.scss`
-- global app stylesheet entry -> `src/main/webapp/src/assets/main.scss`
-- theme configuration -> `src/main/webapp/src/plugins/vuetify.ts`
+Vuetify components are the foundation; a Tabler-inspired visual language is applied through shared overrides in `tabler-overrides.scss`. Never bypass Vuetify components for raw HTML just to match Tabler aesthetics.
 
 ### Style loading order
 
-The application entrypoint (`src/main/webapp/src/main.ts`) imports styles in this order, which must be preserved so project styles can override library defaults predictably:
+The entrypoint (`src/main/webapp/src/main.ts`) loads styles in this order (must be preserved):
 
 1. `vuetify/styles` — Vuetify base styles
 2. `@mdi/font/css/materialdesignicons.css` — MDI icons
-3. `./assets/main.scss` — app typography and Tabler overrides
+3. `./assets/main.scss` — app styles (includes Tabler overrides)
+
+### Global style locations
+
+- Component-scoped styles → `<style scoped>` inside `.vue` files
+- Global Vuetify overrides → `tabler-overrides.scss`
+- Theme configuration → `plugins/vuetify.ts`
 
 ### Chart architecture
 
-ECharts is registered globally in `src/main/webapp/src/main.ts` through `vue-echarts`. Only the needed renderers, charts, and components are imported to keep the bundle lean (`CanvasRenderer`, `PieChart`, `LineChart`, `BarChart`, `RadarChart`, `FunnelChart`, `HeatmapChart`, and related ECharts components). A global `VChart` component is registered for use in views.
-
-Architecturally, that means:
-
-- chart bootstrapping belongs in application setup
-- chart rendering belongs in components/views
-- new chart types should be added to the shared registration path, not bootstrapped ad hoc in random components
+ECharts is registered globally in `main.ts` via `vue-echarts` with only needed chart types imported (tree-shaken). New chart types must be added to the shared registration path in `main.ts`, not bootstrapped ad hoc in components. Chart wrappers use `.chart-wrapper` class.
 
 ### Markdown architecture
 
-Markdown editing and rendering should be treated as first-class application capabilities.
-
-Recommended separation:
-
-- editing layer -> editor component integration
-- rendering layer -> safe markdown rendering
-- persistence layer -> backend-stored or backend-generated markdown
-- AI layer -> markdown generation or transformation workflows
-
-Keep markdown human-readable first, even when it is AI-generated.
+Markdown is a first-class content format. The architecture separates editing (`md-editor-v3`), rendering (`marked` + sanitisation), persistence (backend), and generation (AI). See [`DESIGN.md §5`](./DESIGN.md) for the full markdown conventions.
 
 ---
 
@@ -416,16 +404,13 @@ Before merging a structural change, confirm:
 
 ## Related Docs
 
-- `AGENTS.md`
-- `DESIGN.md`
-- `CONTRIBUTING.md`
-- `DEVELOPMENT.md`
-
-Future linked docs:
-
-- `API.md`
-- `DATA_MODEL.md`
-- `SECURITY.md`
-- `PROMPTS.md`
-- `AI_CONTEXT.md`
-- `TESTING.md`
+- [`AGENTS.md`](./AGENTS.md) — AI agent catalogue and prompt architecture
+- [`DESIGN.md`](./DESIGN.md) — system design, UI language, design decisions
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — contribution workflow and rules
+- [`DEVELOPMENT.md`](./DEVELOPMENT.md) — local setup and daily routine
+- [`API.md`](./API.md) — REST API contract
+- [`DATA_MODEL.md`](./DATA_MODEL.md) — domain entities and JPA conventions
+- [`SECURITY.md`](./SECURITY.md) — authentication and authorization model
+- [`PROMPTS.md`](./PROMPTS.md) — prompt template documentation
+- [`AI_CONTEXT.md`](./AI_CONTEXT.md) — compact project context for AI tools
+- [`TESTING.md`](./TESTING.md) — testing strategy and conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,18 +9,11 @@ This project combines a Kotlin/Spring Boot backend with a Vue 3 + Vuetify fronte
 ## Table of Contents
 
 1. [Scope](#scope)
-2. [Project Structure](#project-structure)
-3. [Environment Setup](#environment-setup)
-4. [Build & Dev Commands](#build--dev-commands)
-5. [Core Principles](#core-principles)
-6. [Development Workflow](#development-workflow)
-7. [Coding Conventions](#coding-conventions)
-8. [Frontend Rules](#frontend-rules)
-9. [Backend Rules](#backend-rules)
-10. [Security Constraints](#security-constraints)
-11. [Documentation Rules](#documentation-rules)
-12. [Pull Requests](#pull-requests)
-13. [Commit Messages](#commit-messages)
+2. [Core Principles](#core-principles)
+3. [Development Workflow](#development-workflow)
+4. [Documentation Rules](#documentation-rules)
+5. [Pull Requests](#pull-requests)
+6. [Commit Messages](#commit-messages)
 
 ---
 
@@ -35,147 +28,22 @@ This repository prefers:
 - consistency over cleverness
 - readable code over over-abstraction
 
----
+### Quick Reference — where to find the rules
 
-## Project Structure
-
-The repository contains both backend and frontend code in one place.
-
-```text
-opportune/
-├── build.gradle.kts
-├── package.json
-├── AGENTS.md
-├── DESIGN.md
-├── CONTRIBUTING.md
-├── src/main/
-│   ├── kotlin/com/glinboy/opportune/
-│   │   ├── aop/          # Cross-cutting concerns (logging, auditing aspects)
-│   │   ├── config/       # Spring configuration beans (Security, Jackson, OpenAPI, etc.)
-│   │   ├── dto/          # Data Transfer Objects (request/response shapes)
-│   │   ├── entity/       # JPA entities
-│   │   ├── enums/        # Shared enumerations (Role, ApplicationStatus, etc.)
-│   │   ├── event/        # Spring application events (e.g. ApplicationSubmittedEvent)
-│   │   ├── mapper/       # MapStruct mappers (entity ↔ DTO)
-│   │   ├── projection/   # JPA interface projections for lightweight queries
-│   │   ├── repository/   # Spring Data JPA repositories
-│   │   ├── security/     # JWT utilities, SecurityUtils, auth converters
-│   │   ├── service/      # Business logic (interfaces + impl/ sub-package)
-│   │   ├── util/         # Shared utilities
-│   │   └── web/          # REST controllers, filters, exception handlers
-│   ├── resources/
-│   │   ├── config/       # application.yml and profile overrides
-│   │   ├── db/migration/ # Flyway SQL migration scripts
-│   │   ├── prompts/      # Spring AI prompt templates (.st files)
-│   │   └── templates/    # Thymeleaf email templates
-│   └── webapp/
-│       └── src/
-│           ├── assets/       # SCSS entry points and tabler-overrides.scss
-│           ├── components/   # Reusable UI components
-│           ├── composables/  # Shared reactive logic (useXxx pattern)
-│           ├── layouts/      # Page layout shells
-│           ├── models/       # TypeScript interfaces — pure data shapes
-│           ├── plugins/      # Vuetify plugin config (theme, defaults)
-│           ├── router/       # Vue Router route definitions
-│           ├── services/     # Axios API call wrappers — one file per domain
-│           ├── stores/       # Pinia stores — one file per domain
-│           ├── utils/        # Pure helper functions (no Vue reactivity)
-│           └── views/        # Page-level components (route targets)
-└── src/test/
-    └── kotlin/               # Mirrors main package layout; test profile uses H2
-```
-
-When adding new files, place them in the most specific domain-oriented folder possible.
-
----
-
-## Environment Setup
-
-### Prerequisites
-
-| Tool       | Version                                                           |
-| ---------- | ----------------------------------------------------------------- |
-| JDK        | 24 (managed by Gradle toolchain — downloaded automatically)       |
-| Node.js    | 24.x (managed by `node-gradle` plugin — downloaded automatically) |
-| PostgreSQL | 14+ (only required for `prod` profile; dev uses H2 in-memory)     |
-
-### Environment file
-
-The backend reads credentials and settings from a `.env.<profile>` file at startup.
-Copy the provided example and fill in the required values:
-
-```bash
-cp .env.dev.example .env.dev   # never commit the filled-in file
-```
-
-**Required variables (`dev` profile):**
-
-| Variable                                    | Required | Description                             |
-| ------------------------------------------- | -------- | --------------------------------------- |
-| `SPRING_AI_OPENAI_API_KEY`                  | Yes      | OpenAI secret key — never hardcode this |
-| `SPRING_AI_OPENAI_CHAT_OPTIONS_MODEL`       | No       | Override model (default: `gpt-4o-mini`) |
-| `SPRING_AI_OPENAI_CHAT_OPTIONS_TEMPERATURE` | No       | Override temperature (default: `0.7`)   |
-
-Profile env files (`.env.dev`, `.env.prod`) are git-ignored. Gradle loads them
-automatically via the `loadEnvFile()` helper in `build.gradle.kts`.
-
-### Docker Compose (backing services only)
-
-```bash
-docker compose up -d   # starts PostgreSQL; only needed for the prod profile
-```
-
-The application itself is run via Gradle, not Docker, during development.
-
----
-
-## Build & Dev Commands
-
-### Backend
-
-```bash
-# Start the backend with the dev profile (H2 in-memory database)
-./gradlew bootRun -Pprofile=dev
-
-# Start the backend with the prod profile (requires PostgreSQL via compose.yaml)
-./gradlew bootRun -Pprofile=prod
-
-# Build a self-contained production JAR (also builds and bundles the frontend)
-./gradlew bootJar
-
-# Run all backend tests
-./gradlew test -Pprofile=test
-
-# Clean all build artefacts
-./gradlew clean
-```
-
-> **Note:** `./gradlew bootJar` depends on `buildFrontend`, which runs `npm install`
-> then `npm run build` automatically. Do not run them separately unless you are
-> iterating on the frontend alone.
-
-### Frontend (standalone)
-
-```bash
-npm install              # install dependencies (first time or after package.json changes)
-npm run dev              # Vite dev server with HMR at http://localhost:5173
-npm run build            # production build → build/resources/main/static/
-npm run type-check       # vue-tsc type check (no emit)
-npm run lint             # ESLint with auto-fix
-npm run format           # Prettier format src/
-```
-
-### Make targets (convenience)
-
-```bash
-make start      # start both backend and frontend
-make stop       # stop both
-make start-be   # backend only
-make start-fe   # frontend only
-make attach-be  # tail backend logs
-make attach-fe  # tail frontend logs
-make status     # show running/stopped services
-```
+| Topic                    | Primary document                 |
+| ------------------------ | -------------------------------- |
+| Project structure        | [`AGENTS.md §4`](./AGENTS.md)    |
+| Local setup & commands   | [`DEVELOPMENT.md`](./DEVELOPMENT.md) |
+| Kotlin conventions       | [`AGENTS.md §7`](./AGENTS.md)    |
+| Frontend conventions     | [`DESIGN.md §4–5`](./DESIGN.md)  |
+| UI design language       | [`DESIGN.md §5`](./DESIGN.md)    |
+| AI agents & prompts      | [`AGENTS.md §9–10`](./AGENTS.md) |
+| API contract             | [`API.md`](./API.md)             |
+| Data model               | [`DATA_MODEL.md`](./DATA_MODEL.md) |
+| Security model           | [`SECURITY.md`](./SECURITY.md)   |
+| Testing strategy         | [`TESTING.md`](./TESTING.md)     |
+| Prompt template details  | [`PROMPTS.md`](./PROMPTS.md)     |
+| Architecture decisions   | [`ARCHITECTURE.md`](./ARCHITECTURE.md) |
 
 ---
 
@@ -183,15 +51,12 @@ make status     # show running/stopped services
 
 ### 1. Preserve the architecture
 
-Follow the existing separation of responsibilities:
+Follow the existing separation of responsibilities — see [`ARCHITECTURE.md`](./ARCHITECTURE.md) for the full layering rules.
 
-- Controllers handle HTTP concerns.
-- Services contain business logic.
-- Repositories contain persistence logic only.
-- Views stay thin.
-- Stores manage shared frontend state.
-- Services on the frontend wrap API calls.
-- Composables hold reusable reactive logic.
+At a high level:
+
+- **Backend:** Controllers handle HTTP concerns, Services contain business logic, Repositories contain persistence logic only.
+- **Frontend:** Views stay thin, Stores manage shared state, Services wrap API calls, Composables hold reusable reactive logic.
 
 Do not move business logic into controllers, repositories, or large view components.
 
@@ -205,7 +70,7 @@ Choose names and structures that make intent obvious:
 
 ### 3. Document meaningful decisions
 
-If your change affects architecture, AI behavior, prompts, security, styling strategy, or domain language, update the relevant markdown file in the repo root.
+If your change affects architecture, AI behavior, prompts, security, styling strategy, or domain language, update the relevant markdown file in the repo root. See [Documentation Rules](#documentation-rules) below for which file to update.
 
 Code and docs should evolve together.
 
@@ -232,8 +97,8 @@ Examples:
 
 ### Before starting
 
-1. Read `AGENTS.md` if your change touches AI behavior.
-2. Read `DESIGN.md` if your change affects architecture, UI patterns, or app structure.
+1. Read [`AGENTS.md`](./AGENTS.md) if your change touches AI behavior.
+2. Read [`DESIGN.md`](./DESIGN.md) if your change affects architecture, UI patterns, or app structure.
 3. Check whether an existing folder or service already covers your use case.
 4. Prefer extending existing patterns over introducing a parallel one.
 
@@ -248,269 +113,15 @@ A pull request should ideally do one thing well:
 
 Avoid mixing unrelated UI, backend, and docs changes unless they are directly coupled.
 
----
-
-## Coding Conventions
-
-### General
-
-- Prefer small, composable units.
-- Avoid dead code and commented-out code.
-- Do not add speculative abstractions "for future use".
-- Keep naming domain-driven and consistent.
-- Add comments only when the intent is not obvious from the code itself.
-
-### File naming
-
-Use the conventions already natural to the stack:
-
-- Kotlin classes: `PascalCase`
-- Vue single-file components: `PascalCase.vue`
-- TypeScript utility/service/store files: consistent project-local naming, preferably descriptive and domain-based
-- Markdown docs in repo root: uppercase file names like `AGENTS.md`, `DESIGN.md`, `CONTRIBUTING.md`
-
-### Tests
-
-Add or update tests when changing behavior, especially for:
-
-- business logic
-- auth/security behavior
-- AI orchestration behavior
-- parsing or transformation logic
-- critical UI flows
-
-**Backend unit & integration tests:**
-
-```bash
-./gradlew test -Pprofile=test
-```
-
-Tests run against H2 in-memory DB using the `test` Spring profile.
-Config lives in `src/test/resources/config/application-test.yml`.
-
-**Frontend unit tests (Vitest):**
-
-```bash
-npm run test:unit
-```
-
-**E2E tests (Cypress):**
-
-```bash
-# Open Cypress against the running Vite dev server
-npm run test:e2e:dev
-
-# Headless run against a production preview build
-npm run test:e2e
-```
-
-**AI-specific testing rules:**
-
-- **Never make real API calls in tests.** Mock `ChatClient` / `StreamingChatClient`.
-- Assert prompt _variable injection_, not LLM output content.
-- Use `cy.intercept` in Cypress to stub all `/api/v1/ai/**` routes.
-- AI integration tests live under `src/test/kotlin/.../ai/`.
-
----
-
-## Frontend Rules
-
-### Use Vuetify components
-
-This project uses **Vuetify components with a Tabler-inspired visual language**.
-
-That means:
-
-- use Vuetify for components
-- do not replace Vuetify components with raw HTML just for styling
-- apply the design language through theme/configuration and shared overrides
-
-### Respect the Tabler styling approach
-
-The Tabler-inspired look is implemented through shared stylesheet overrides.
-
-Current global styling guidance:
-
-- global component-level visual overrides belong in `src/main/webapp/src/assets/tabler-overrides.scss`
-- app-level style entry belongs in `src/main/webapp/src/assets/main.scss`
-- Vuetify theme configuration belongs in `src/main/webapp/src/plugins/vuetify.ts`
-- local component-specific styles belong in scoped styles inside the component
-
-Do not duplicate global styling rules in random component files.
-
-### Keep views thin
-
-In the frontend:
-
-- `views/` are route-level screens
-- `components/` are reusable UI pieces
-- `stores/` hold shared state
-- `services/` wrap API calls
-- `composables/` hold reusable reactive logic
-- `utils/` contain pure helpers
-
-If a view becomes large, split it into components and composables.
-
-### Charts
-
-Charts are registered globally and should follow the existing chart setup. When introducing a new chart type, align with the current shared registration pattern instead of creating one-off chart bootstrapping inside a component.
-
-Specifically: import and register the new chart type in `main.ts`, not inside individual components. Chart wrapper elements should carry the `.chart-wrapper` class to pick up the shared `tabler-overrides.scss` rule that enforces `width: 100%; aspect-ratio: 16/9; overflow: hidden`.
-
-### Markdown features
-
-If you work on markdown editing or rendering:
-
-- editing should align with the existing markdown editor approach
-- rendering should remain safe and predictable
-- generated markdown should be readable by humans first
-
-### Style loading order
-
-The import order in `main.ts` is **intentional and must be preserved**:
-
-```ts
-import 'vuetify/styles' // 1. Vuetify base — lowest specificity
-import '@mdi/font/css/materialdesignicons.css' // 2. Icon font
-import './assets/main.scss' // 3. App styles (includes tabler-overrides.scss)
-```
-
-`tabler-overrides.scss` is imported from `main.scss` and wins over Vuetify by loading last.
-Never reorder these imports.
-
-### Theme compliance
-
-The app ships two named Vuetify themes: `tablerLight` (default) and `tablerDark`.
-
-Rules:
-
-- **Never hardcode** `background`, `surface`, or text colours with hex values in components.
-  Always use `var(--v-theme-*)` CSS custom properties or Vuetify's colour utility classes so
-  the component works correctly in both themes.
-- The only intentionally theme-fixed values are the structural neutral borders in
-  `tabler-overrides.scss` (`rgba(101, 109, 119, …)`).
-- Third-party components that have their own dark/light prop must be synced manually by
-  reading `vuetifyTheme.global.current.value.dark`. Follow the pattern already used in
-  `MdEditor.vue`.
-
-### State management
-
-Follow the Pinia conventions:
-
-- **Stores** (`stores/`) manage server-fetched data, loading/error states, and domain actions.
-- **Services** (`services/`) contain only Axios calls — no reactive state.
-- **Composables** (`composables/`) contain reusable local reactive logic that does not need
-  to be globally shared.
-- Do not put Axios call logic directly inside Pinia actions — delegate to a service function
-  and call it from the action.
-
-### User feedback (toast notifications)
-
-Every async operation that can succeed or fail must give the user visible feedback.
-Silent failures are not acceptable.
-
-Use the global `useToastStore()` from `stores/toast.ts`. Components call the store; they
-do not own snackbar state themselves.
-
-```ts
-const toast = useToastStore()
-try {
-  await someApiCall()
-  toast.success('Saved successfully')
-} catch {
-  toast.error('Something went wrong. Please try again.')
-}
-```
-
-Rules:
-
-- **Always** show a toast on API error — never swallow exceptions silently.
-- **Always** confirm destructive or long-running actions with a success toast on completion.
-- Use `toast.success()` / `toast.error()` / `toast.warning()` / `toast.info()`.
-- **Never** add a `<v-snackbar>` or local snackbar reactive state inside a component.
-
----
-
-## Backend Rules
-
-### Service boundaries
-
-Backend logic should generally follow this flow:
-
-`Controller -> Service -> Repository`
-
-Keep these responsibilities clear:
-
-- Controller: HTTP mapping, validation boundary, response shape
-- Service: orchestration, business rules, AI calls, parsing, workflows
-- Repository: persistence only
-
-### Database changes
-
-When changing the schema:
-
-- add a new Flyway migration
-- never rewrite an already-applied migration
-- keep migration names descriptive
-
-### AI integration
-
-If your change affects prompts, model inputs, AI outputs, or agent behavior:
-
-1. **Add or update a prompt file** in `src/main/resources/prompts/` (`.st` extension,
-   StringTemplate format). Follow the structure in [`AGENTS.md §10`](./AGENTS.md).
-2. **Create or extend an AI service** in `service/impl/`, injecting `ChatClient`
-   (or `StreamingChatClient` for SSE responses).
-3. **Expose a controller endpoint** under `/api/v1/ai/{feature}` — secured by default
-   via Spring Security (no extra configuration needed for standard API paths).
-4. **Document the agent** in `AGENTS.md §9` and update its status from 🔲 to ✅.
-5. **Write a unit test** that mocks `ChatClient` and asserts prompt variable injection —
-   never assert on LLM output content.
-6. **Run the full test suite** before submitting: `./gradlew test -Pprofile=test`.
-
-**Prompt authoring rules:**
-
-- Be explicit about the expected output format (Markdown, JSON, plain text).
-- Include this safety line in every prompt:
-  _"Do not invent information. If a field cannot be determined, leave it blank."_
-- Wrap any user-supplied text in delimiters to defend against prompt injection:
-  ```
-  ---BEGIN USER TEXT---
-  {userContent}
-  ---END USER TEXT---
-  ```
-- Never embed API keys or user PII inside prompt files — use `{variable}` placeholders only.
-- If the prompt includes a JSON schema with curly braces, load the file as raw text and
-  perform string substitution manually (see `AiServiceImpl` for the established pattern).
-
-Avoid hiding prompt logic across many unrelated files. Keep all prompt files in
-`src/main/resources/prompts/` and all AI orchestration in the service layer.
-
-### Security
-
-Treat authentication and authorization changes as high-risk:
-
-- keep JWT/OAuth-related changes minimal and reviewed
-- document any new claim, role, scope, or access rule
-- do not weaken defaults for convenience
-
----
-
-## Security Constraints
-
-Treat these rules as hard requirements, not guidelines:
-
-| Constraint                   | Rule                                                                                                                                                         |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| No unauthenticated AI access | All `/api/v1/ai/**` endpoints are protected by Spring Security. Do not add bypass logic.                                                                     |
-| No PII in logs               | AI service methods must **not** log prompt content at `INFO` or above.                                                                                       |
-| User data isolation          | Every query and AI call must be scoped to the authenticated user via `SecurityUtils.getCurrentUserLoginID()`. Never return data across user boundaries.      |
-| Prompt injection defence     | User-supplied text injected into prompts must be wrapped in `---BEGIN USER TEXT--- / ---END USER TEXT---` delimiters.                                        |
-| API key management           | The OpenAI key is loaded from `SPRING_AI_OPENAI_API_KEY`. Never hardcode it in source files or `application.yml`.                                            |
-| Output sanitisation          | AI-generated HTML rendered on the frontend must be passed through DOMPurify before insertion into the DOM.                                                   |
-| JWT / OAuth changes          | Keep JWT/OAuth-related changes minimal and thoroughly reviewed. Do not weaken defaults for convenience. Document any new claim, role, scope, or access rule. |
-
-When in doubt about a security decision, err on the side of restriction and document why.
+### Daily routine
+
+1. Pull the latest `develop`
+2. Create a focused branch
+3. Make one coherent change
+4. Test the affected areas — run backend tests (`./gradlew test -Pprofile=test`) and frontend unit tests (`npm run test:unit`). See [`TESTING.md`](./TESTING.md) for full strategy.
+5. Update docs if the change affects architecture, UI rules, AI behavior, or workflow
+6. Commit with a clear message
+7. Open a PR
 
 ---
 
@@ -518,23 +129,22 @@ When in doubt about a security decision, err on the side of restriction and docu
 
 ### Root documentation files
 
-This repo uses root-level markdown files as shared operational memory for contributors and AI tools.
+This repo uses root-level markdown files as shared operational memory for contributors and AI tools. When a change introduces a new important concept, update docs in the same branch.
 
-All root documentation files:
+### What to update when
 
-- `AGENTS.md`
-- `DESIGN.md`
-- `CONTRIBUTING.md`
-- `DEVELOPMENT.md`
-- `ARCHITECTURE.md`
-- `API.md`
-- `SECURITY.md`
-- `DATA_MODEL.md`
-- `PROMPTS.md`
-- `TESTING.md`
-- `AI_CONTEXT.md`
-
-When a change introduces a new important concept, update docs in the same branch.
+| Change affects…                  | Update…                            |
+| -------------------------------- | ---------------------------------- |
+| AI behavior, prompts, agents     | [`AGENTS.md`](./AGENTS.md)         |
+| Structural layering              | [`ARCHITECTURE.md`](./ARCHITECTURE.md) |
+| UI conventions, design language  | [`DESIGN.md`](./DESIGN.md)         |
+| Local setup, dev commands        | [`DEVELOPMENT.md`](./DEVELOPMENT.md) |
+| API contract, endpoints          | [`API.md`](./API.md)               |
+| Security model                   | [`SECURITY.md`](./SECURITY.md)     |
+| Data model, entities             | [`DATA_MODEL.md`](./DATA_MODEL.md) |
+| Prompt templates                 | [`PROMPTS.md`](./PROMPTS.md)       |
+| Test strategy                    | [`TESTING.md`](./TESTING.md)       |
+| Contribution process             | This file                         |
 
 ### Obsidian-friendly documentation
 
@@ -547,11 +157,6 @@ Preferred practices:
 - links between docs using relative markdown links
 - one main topic per file
 - avoid burying architectural decisions inside issue threads only
-
-Good examples:
-
-- `[Design decisions](./DESIGN.md)`
-- `[AI agent catalogue](./AGENTS.md)`
 
 The goal is that the repo docs can also act as a lightweight knowledge graph for the application.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -445,57 +445,15 @@ Stateless auth simplifies horizontal scaling and removes the need for a distribu
 
 ## 9. Folder Structure Reference
 
-```
-opportune/
-├── build.gradle.kts                   # Unified build: backend + frontend
-├── AGENTS.md                          # AI agent catalogue
-├── DESIGN.md                          # This file
-│
-├── src/main/
-│   ├── kotlin/                        # Backend source
-│   │   └── …/opportune/
-│   │       ├── aop/                   # Cross-cutting concerns (logging, auditing aspects)
-│   │       ├── config/                # Spring configuration beans (Security, Jackson, OpenAPI, etc.)
-│   │       ├── dto/                   # Data Transfer Objects (request/response shapes)
-│   │       ├── entity/                # JPA entities
-│   │       ├── enums/                 # Shared enumerations (Role, ApplicationStatus, etc.)
-│   │       ├── event/                 # Spring application events
-│   │       ├── mapper/                # MapStruct mappers (entity ↔ DTO)
-│   │       ├── projection/            # JPA interface projections for lightweight queries
-│   │       ├── repository/            # Spring Data JPA repositories
-│   │       ├── security/              # JWT utilities, SecurityUtils, auth converters
-│   │       ├── service/               # Business logic (interfaces + impl/ sub-package)
-│   │       ├── util/                  # Shared utilities
-│   │       └── web/                   # REST controllers, filters, exception handlers
-│   │
-│   ├── resources/
-│   │   ├── application.yml            # Base configuration
-│   │   ├── application-*.yml          # Profile-specific overrides
-│   │   ├── db/migration/              # Flyway SQL migrations (V{n}__{desc}.sql)
-│   │   └── prompts/                   # Spring AI prompt templates (.st files)
-│   │
-│   └── webapp/                        # Frontend root (Vite project)
-│       ├── package.json
-│       ├── vite.config.ts
-│       └── src/
-│           ├── assets/
-│           │   ├── main.scss
-│           │   └── tabler-overrides.scss   # ← Tabler design language
-│           ├── components/
-│           ├── composables/
-│           ├── layouts/
-│           ├── models/
-│           ├── plugins/vuetify.ts          # ← Vuetify theme config
-│           ├── router/
-│           ├── services/
-│           ├── stores/
-│           ├── utils/
-│           ├── views/
-│           ├── App.vue
-│           └── main.ts                    # ← Style loading order defined here
-│
-└── src/test/                          # Backend tests (JUnit 5)
-```
+The full project directory tree is maintained in [`AGENTS.md §4`](./AGENTS.md). Key paths for design work:
+
+| Path                                               | Design relevance                                           |
+| -------------------------------------------------- | ---------------------------------------------------------- |
+| `src/main/webapp/src/plugins/vuetify.ts`           | Vuetify theme config (`tablerLight` / `tablerDark`)        |
+| `src/main/webapp/src/assets/tabler-overrides.scss` | Global Vuetify visual overrides (Tabler design language)   |
+| `src/main/webapp/src/assets/main.scss`             | App-level style entry — imports `tabler-overrides.scss`    |
+| `src/main/webapp/src/main.ts`                      | Style loading order, ECharts registration                  |
+| `src/main/resources/prompts/`                      | AI prompt templates (.st files)                            |
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -217,6 +217,8 @@ Use this structure consistently:
 - `utils/` for pure helpers
 - `models/` for TypeScript data shapes
 - `layouts/` for app shells and layout wrappers
+- `plugins/` for framework/plugin setup
+- `assets/` for global styles and static assets
 
 If a view gets too large, split it before adding more logic.
 
@@ -288,7 +290,7 @@ Keep AI behavior explicit and documented.
 
 ## Testing During Development
 
-Run tests early and often.
+Run tests early and often. See [`TESTING.md`](./TESTING.md) for the full strategy, conventions, and CI behaviour.
 
 ### Backend unit & integration tests
 


### PR DESCRIPTION
Closes #124

## Summary

Reviewed all 13 root-level markdown documentation files and fixed issues with duplicate content, stale project trees, and missing cross-references.

## Changes

| Commit | File | What changed |
|--------|------|-------------|
| `2c11ca9` | CONTRIBUTING.md | Deduplicated 7 sections (648→253 lines). Removed environment setup, build commands, testing commands, frontend/backend rules, security constraints — all replaced with a Quick Reference table pointing to canonical docs |
| `541d9bf` | DESIGN.md §9 | Replaced 50-line project tree with compact reference table |
| `fb68854` | ARCHITECTURE.md | Updated stale trees with real sub-packages, collapsed verbose UI section into cross-ref to DESIGN.md §5, replaced "Future linked docs" with real links |
| `96989ff` | AI_CONTEXT.md | Added proper markdown links to all "What To Update" and "Canonical Docs" sections |
| `4ac90e5` | AGENTS.md §4 | Rebuilt project tree to match actual codebase — `webapp/` was a single empty line, now shows full frontend structure, backend sub-packages, resources subdirs, test structure, plus 15+ missing root files. Added cross-references to DEVELOPMENT.md, TESTING.md, PROMPTS.md, SECURITY.md |
| `34b68bb` | DEVELOPMENT.md | Added TESTING.md cross-ref, fixed folder listings (added plugins/, assets/) |

## Key design decisions

- **AGENTS.md** keeps quick-reference content (build commands, env vars) because it's the primary entry point for AI agents — intentionally self-contained
- **CONTRIBUTING.md** now delegates all technical details to specialized docs — it only keeps workflow, PR, and commit message guidance
- **ARCHITECTURE.md** defers UI design specifics to DESIGN.md — keeps only structural layering rules