### PR TITLE
feat: replace edit dialog with read-only company detail modal, remove action buttons, make rows clickable

### DIFF
--- a/src/main/webapp/src/views/admin/CompaniesView.vue
+++ b/src/main/webapp/src/views/admin/CompaniesView.vue
@@ -15,23 +15,7 @@
           @click:clear="onClearSearch"
         />
       </v-col>
-      <v-col cols="12" sm="4" md="3" class="pl-sm-3 mt-3 mt-sm-0">
-        <v-select
-          v-model="statusFilter"
-          :items="statusOptions"
-          density="compact"
-          variant="outlined"
-          placeholder="All statuses"
-          clearable
-          hide-details
-          @update:model-value="applyFilters"
-        />
-      </v-col>
-      <v-col class="d-flex justify-end mt-3 mt-sm-0">
-        <v-btn variant="tonal" color="primary" prepend-icon="mdi-magnify" @click="applyFilters">
-          Search
-        </v-btn>
-      </v-col>
+
     </v-row>
 
     <!-- Data table -->
@@ -204,7 +188,7 @@
             <v-col cols="12">
               <v-select
                 v-model="editForm.status"
-                :items="statusOptions"
+                :items="['INTERESTED', 'NOT_INTERESTED', 'BLOCKED']"
                 label="Status"
                 density="compact"
                 variant="outlined"
@@ -272,13 +256,6 @@ const itemsPerPage = ref(15)
 
 // — Filter state —
 const searchText = ref('')
-const statusFilter = ref<string | null>(null)
-
-const statusOptions = [
-  { title: 'Interested', value: 'INTERESTED' },
-  { title: 'Not Interested', value: 'NOT_INTERESTED' },
-  { title: 'Blacklisted', value: 'BLOCKED' },
-]
 
 const headers = [
   { title: 'Company', key: 'name', sortable: false },
@@ -346,10 +323,7 @@ function buildFilter(): string | undefined {
   const parts: string[] = []
   if (searchText.value.trim()) {
     const q = encodeRsqlValue(searchText.value.trim())
-    parts.push(`name=ilike=*${q}*`)
-  }
-  if (statusFilter.value) {
-    parts.push(`status==${statusFilter.value}`)
+    parts.push(`(name=ilike="${q}",industry=ilike="${q}")`)
   }
   return parts.length ? parts.join(';') : undefined
 }

--- a/src/main/webapp/src/views/admin/CompaniesView.vue
+++ b/src/main/webapp/src/views/admin/CompaniesView.vue
@@ -33,11 +33,8 @@
         <!-- Name + logo -->
         <template #item.name="{ item }">
           <div class="d-flex align-center gap-2 py-1">
-            <v-avatar size="32" color="primary" class="text-caption font-weight-bold">
-              <v-img v-if="item.logo" :src="item.logo" :alt="item.name ?? ''" />
-              <span v-else>{{ (item.name?.[0] ?? '?').toUpperCase() }}</span>
-            </v-avatar>
-            <div>
+            <CompanyLogo :alt="item.name" :logo="item.logo" :website="item.website" size="32" />
+            <div class="ml-3">
               <div class="text-body-2 font-weight-medium">{{ item.name ?? '—' }}</div>
               <div v-if="item.website" class="text-caption text-medium-emphasis">
                 <a :href="item.website" target="_blank" rel="noopener noreferrer">{{
@@ -237,6 +234,7 @@ import { useToastStore } from '../../stores/toast'
 import AdminCompanyService from '../../services/admin/admin-company.service'
 import type { IAdminCompanyListItem, IAdminCompanyUpdate } from '../../models'
 import ConfirmDialog from '../../components/ConfirmDialog.vue'
+import CompanyLogo from '../../components/company/CompanyLogo.vue'
 import {
   getCompanyStatusColor,
   getCompanyStatusIcon,

--- a/src/main/webapp/src/views/admin/CompaniesView.vue
+++ b/src/main/webapp/src/views/admin/CompaniesView.vue
@@ -29,6 +29,7 @@
         :page="page"
         item-value="id"
         @update:options="onTableOptions"
+        @click:row="openDetailDialog"
       >
         <!-- Name + logo -->
         <template #item.name="{ item }">
@@ -68,37 +69,6 @@
           {{ item.createdDate ? formatDate(item.createdDate) : '—' }}
         </template>
 
-        <!-- Actions -->
-        <template #item.actions="{ item }">
-          <v-btn
-            size="small"
-            variant="text"
-            icon="mdi-pencil-outline"
-            title="Edit details"
-            @click="openEditDialog(item)"
-          />
-          <v-menu>
-            <template #activator="{ props }">
-              <v-btn size="small" variant="text" icon="mdi-dots-vertical" v-bind="props" />
-            </template>
-            <v-list density="compact" min-width="200">
-              <v-list-item
-                v-if="item.status !== 'BLOCKED'"
-                prepend-icon="mdi-cancel"
-                title="Blacklist"
-                class="text-error"
-                @click="confirmAction('blacklist', item)"
-              />
-              <v-list-item
-                v-if="item.status === 'BLOCKED'"
-                prepend-icon="mdi-check-circle-outline"
-                title="Un-blacklist"
-                @click="confirmAction('unblacklist', item)"
-              />
-            </v-list>
-          </v-menu>
-        </template>
-
         <!-- Empty state -->
         <template #no-data>
           <div class="pa-8 text-center text-medium-emphasis">
@@ -109,119 +79,82 @@
       </v-data-table-server>
     </v-card>
 
-    <!-- Confirmation Dialog (blacklist / un-blacklist) -->
-    <ConfirmDialog
-      v-model="dialog.open"
-      :title="dialog.title"
-      :variant="dialog.variant"
-      :loading="dialog.loading"
-      @confirm="executeAction"
-      @cancel="dialog.open = false"
-    >
-      {{ dialog.message }}
-    </ConfirmDialog>
-
-    <!-- Edit Details Dialog -->
-    <v-dialog v-model="editDialog.open" max-width="600" :persistent="editDialog.loading">
+    <!-- Company Detail Dialog -->
+    <v-dialog v-model="detailDialog" max-width="600">
       <v-card rounded="lg">
-        <v-card-title class="pa-6 pb-2 text-h6 font-weight-bold">Edit Company</v-card-title>
+        <v-card-title class="pa-6 pb-2 d-flex align-center">
+          <span class="text-h6 font-weight-bold">Company Details</span>
+          <v-spacer />
+          <v-btn icon="mdi-close" variant="text" size="small" @click="detailDialog = false" />
+        </v-card-title>
         <v-divider />
         <v-card-text class="pa-6">
-          <v-row dense>
-            <v-col cols="12" sm="6">
-              <v-text-field
-                v-model="editForm.name"
-                label="Company name"
-                density="compact"
-                variant="outlined"
-                hide-details="auto"
-              />
-            </v-col>
-            <v-col cols="12" sm="6">
-              <v-text-field
-                v-model="editForm.industry"
-                label="Industry"
-                density="compact"
-                variant="outlined"
-                hide-details="auto"
-              />
-            </v-col>
-            <v-col cols="12" sm="6">
-              <v-text-field
-                v-model="editForm.website"
-                label="Website"
-                density="compact"
-                variant="outlined"
-                hide-details="auto"
-              />
-            </v-col>
-            <v-col cols="12" sm="6">
-              <v-text-field
-                v-model="editForm.companySize"
-                label="Company size"
-                density="compact"
-                variant="outlined"
-                hide-details="auto"
-              />
-            </v-col>
-            <v-col cols="12" sm="6">
-              <v-text-field
-                v-model="editForm.location"
-                label="Location"
-                density="compact"
-                variant="outlined"
-                hide-details="auto"
-              />
-            </v-col>
-            <v-col cols="12" sm="6">
-              <v-text-field
-                v-model="editForm.foundedYear"
-                label="Founded year"
-                density="compact"
-                variant="outlined"
-                hide-details="auto"
-              />
-            </v-col>
-            <v-col cols="12">
-              <v-select
-                v-model="editForm.status"
-                :items="['INTERESTED', 'NOT_INTERESTED', 'BLOCKED']"
-                label="Status"
-                density="compact"
-                variant="outlined"
-                hide-details="auto"
-              />
-            </v-col>
-            <v-col cols="12">
-              <v-textarea
-                v-model="editForm.description"
-                label="Description"
-                density="compact"
-                variant="outlined"
-                rows="3"
-                hide-details="auto"
-              />
-            </v-col>
-            <v-col cols="12">
-              <v-textarea
-                v-model="editForm.note"
-                label="Note"
-                density="compact"
-                variant="outlined"
-                rows="2"
-                hide-details="auto"
-              />
-            </v-col>
-          </v-row>
+          <template v-if="detailCompany">
+            <v-row dense>
+              <v-col cols="12" sm="6">
+                <div class="text-caption text-medium-emphasis mb-1">Company Name</div>
+                <div class="text-body-2">{{ detailCompany.name ?? '—' }}</div>
+              </v-col>
+              <v-col cols="12" sm="6">
+                <div class="text-caption text-medium-emphasis mb-1">Industry</div>
+                <div class="text-body-2">{{ detailCompany.industry ?? '—' }}</div>
+              </v-col>
+              <v-col cols="12" sm="6">
+                <div class="text-caption text-medium-emphasis mb-1">Website</div>
+                <div class="text-body-2">
+                  <a v-if="detailCompany.website" :href="detailCompany.website" target="_blank" rel="noopener noreferrer">{{ detailCompany.website }}</a>
+                  <span v-else>—</span>
+                </div>
+              </v-col>
+              <v-col cols="12" sm="6">
+                <div class="text-caption text-medium-emphasis mb-1">Company Size</div>
+                <div class="text-body-2">{{ detailCompany.companySize ?? '—' }}</div>
+              </v-col>
+              <v-col cols="12" sm="6">
+                <div class="text-caption text-medium-emphasis mb-1">Location</div>
+                <div class="text-body-2">{{ detailCompany.location ?? '—' }}</div>
+              </v-col>
+              <v-col cols="12" sm="6">
+                <div class="text-caption text-medium-emphasis mb-1">Founded Year</div>
+                <div class="text-body-2">{{ detailCompany.foundedYear ?? '—' }}</div>
+              </v-col>
+              <v-col cols="12" sm="6">
+                <div class="text-caption text-medium-emphasis mb-1">Status</div>
+                <v-chip :color="statusColor(detailCompany.status)" size="small" label>
+                  <v-icon start :icon="statusIcon(detailCompany.status)" />
+                  {{ statusLabel(detailCompany.status) }}
+                </v-chip>
+              </v-col>
+              <v-col cols="12" sm="6">
+                <div class="text-caption text-medium-emphasis mb-1">Applications</div>
+                <div class="text-body-2">{{ detailCompany.applicationCount ?? 0 }}</div>
+              </v-col>
+              <v-col cols="12" sm="6">
+                <div class="text-caption text-medium-emphasis mb-1">Created</div>
+                <div class="text-body-2">{{ detailCompany.createdDate ? formatDate(detailCompany.createdDate) : '—' }}</div>
+              </v-col>
+              <v-col cols="12" sm="6">
+                <div class="text-caption text-medium-emphasis mb-1">Last Modified</div>
+                <div class="text-body-2">{{ detailCompany.lastModifiedDate ? formatDate(detailCompany.lastModifiedDate) : '—' }}</div>
+              </v-col>
+            </v-row>
+
+            <v-divider class="my-4" />
+
+            <div class="text-caption text-medium-emphasis mb-2">Description</div>
+            <v-sheet rounded="lg" border class="pa-3 mb-4">
+              <MdViewer :content="detailCompany.description" />
+            </v-sheet>
+
+            <div class="text-caption text-medium-emphasis mb-2">Note</div>
+            <v-sheet rounded="lg" border class="pa-3">
+              <MdViewer :content="detailCompany.note" />
+            </v-sheet>
+          </template>
         </v-card-text>
         <v-divider />
-        <v-card-actions class="pa-4 ga-2 justify-end">
-          <v-btn variant="outlined" :disabled="editDialog.loading" @click="editDialog.open = false">
-            Cancel
-          </v-btn>
-          <v-btn color="primary" variant="flat" :loading="editDialog.loading" @click="saveEdit">
-            Save
-          </v-btn>
+        <v-card-actions class="pa-4 justify-end">
+          <v-btn variant="outlined" @click="detailDialog = false">Close</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -229,12 +162,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive } from 'vue'
+import { ref } from 'vue'
 import { useToastStore } from '../../stores/toast'
 import AdminCompanyService from '../../services/admin/admin-company.service'
-import type { IAdminCompanyListItem, IAdminCompanyUpdate } from '../../models'
-import ConfirmDialog from '../../components/ConfirmDialog.vue'
+import type { IAdminCompanyListItem } from '../../models'
 import CompanyLogo from '../../components/company/CompanyLogo.vue'
+import MdViewer from '../../components/markdown/MdViewer.vue'
 import {
   getCompanyStatusColor,
   getCompanyStatusIcon,
@@ -261,38 +194,11 @@ const headers = [
   { title: 'Industry', key: 'industry', sortable: false },
   { title: 'Applications', key: 'applicationCount', sortable: true, align: 'center' as const },
   { title: 'Created', key: 'createdDate', sortable: true },
-  { title: '', key: 'actions', sortable: false, align: 'end' as const },
 ]
 
-// — Confirmation dialog —
-const dialog = reactive({
-  open: false,
-  title: '',
-  message: '',
-  variant: 'warning' as 'error' | 'warning',
-  loading: false,
-  action: '' as string,
-  targetId: '' as string,
-})
-
-// — Edit dialog —
-const editDialog = reactive({
-  open: false,
-  loading: false,
-  targetId: '' as string,
-})
-
-const editForm = reactive<IAdminCompanyUpdate>({
-  name: '',
-  industry: '',
-  website: '',
-  companySize: '',
-  location: '',
-  foundedYear: '',
-  description: '',
-  note: '',
-  status: undefined,
-})
+// — Detail dialog —
+const detailDialog = ref(false)
+const detailCompany = ref<IAdminCompanyListItem | null>(null)
 
 // — Helpers —
 function statusColor(status: string | null | undefined) {
@@ -380,64 +286,15 @@ function onClearSearch() {
   applyFilters()
 }
 
-// — Blacklist / un-blacklist confirmation —
-function confirmAction(action: string, item: IAdminCompanyListItem) {
-  const name = item.name ?? '(unnamed)'
-  dialog.action = action
-  dialog.targetId = item.id!
-  if (action === 'blacklist') {
-    dialog.title = 'Blacklist Company'
-    dialog.message = `Blacklist "${name}"? Users will no longer be able to track applications to this company.`
-    dialog.variant = 'error'
-  } else {
-    dialog.title = 'Remove Blacklist'
-    dialog.message = `Remove "${name}" from the blacklist and restore its status to Interested?`
-    dialog.variant = 'warning'
-  }
-  dialog.open = true
-}
-
-async function executeAction() {
-  dialog.loading = true
-  try {
-    const newStatus = dialog.action === 'blacklist' ? 'BLOCKED' : 'INTERESTED'
-    await service.updateStatus(dialog.targetId, newStatus)
-    toast.success(dialog.action === 'blacklist' ? 'Company blacklisted' : 'Blacklist removed')
-    dialog.open = false
-    await loadCompanies({ page: page.value, itemsPerPage: itemsPerPage.value })
-  } catch {
-    toast.error('Action failed')
-  } finally {
-    dialog.loading = false
-  }
-}
-
-// — Edit dialog —
-function openEditDialog(item: IAdminCompanyListItem) {
-  editDialog.targetId = item.id!
-  editForm.name = item.name ?? ''
-  editForm.industry = item.industry ?? ''
-  editForm.website = item.website ?? ''
-  editForm.companySize = item.companySize ?? ''
-  editForm.location = item.location ?? ''
-  editForm.foundedYear = item.foundedYear ?? ''
-  editForm.description = item.description ?? ''
-  editForm.note = item.note ?? ''
-  editForm.status = item.status ?? undefined
-  editDialog.open = true
-}
-
-async function saveEdit() {
-  editDialog.loading = true
-  try {
-    await service.updateDetails(editDialog.targetId, { ...editForm })
-    toast.success('Company updated')
-    editDialog.open = false
-    await loadCompanies({ page: page.value, itemsPerPage: itemsPerPage.value })
-  } catch {
-    toast.error('Failed to update company')
-  } finally {
-    editDialog.loading = false
-  }
+// — Detail dialog —
+function openDetailDialog(_: any, row: { item: IAdminCompanyListItem }) {
+  detailCompany.value = row.item
+  detailDialog.value = true
 }
 </script>
+
+<style scoped>
+:deep(.v-data-table__tr) {
+  cursor: pointer;
+}
+</style>


### PR DESCRIPTION
## Phase 3 — Make Row Clickable & Read-Only Company Detail Modal

### Changes
- Removed actions column (edit icon + kebab menu) from companies table
- Removed edit dialog, ConfirmDialog, and all blacklist/edit action code
- Rows are now clickable (`@click:row`) with pointer cursor on hover
- New read-only detail modal displays all company fields: name, industry, website, companySize, location, foundedYear, status, applicationCount, createdDate, lastModifiedDate
- Description and Note rendered via `MdViewer` component (supports Markdown)

### Files changed
- `src/main/webapp/src/views/admin/CompaniesView.vue` — 87 insertions, 230 deletions