### PR TITLE
feat: polish security view layout, avatars, date/time, and flags

### DIFF
--- a/src/main/webapp/src/views/admin/SecurityView.vue
+++ b/src/main/webapp/src/views/admin/SecurityView.vue
@@ -22,14 +22,14 @@
             density="compact"
             variant="outlined"
             prepend-inner-icon="mdi-account-search-outline"
-            placeholder="User email…"
+            placeholder="Search by name or email…"
             clearable
             hide-details
             @keyup.enter="loadSessions"
             @click:clear="onClearFilters"
           />
         </v-col>
-        <v-col cols="12" sm="3" md="2" class="pl-sm-2 mt-2 mt-sm-0">
+        <v-col cols="12" sm="6" md="4" class="pl-sm-2 mt-2 mt-sm-0">
           <v-text-field
             v-model="filterIp"
             density="compact"
@@ -66,11 +66,6 @@
             hide-details
             @update:model-value="() => loadSessions()"
           />
-        </v-col>
-        <v-col class="d-flex justify-end mt-2 mt-sm-0 pl-sm-2">
-          <v-btn variant="tonal" color="primary" prepend-icon="mdi-magnify" @click="loadSessions">
-            Search
-          </v-btn>
         </v-col>
       </v-row>
 
@@ -181,14 +176,14 @@
             density="compact"
             variant="outlined"
             prepend-inner-icon="mdi-account-search-outline"
-            placeholder="User email…"
+            placeholder="Search by name or email…"
             clearable
             hide-details
             @keyup.enter="loadAudit"
             @click:clear="onClearAudit"
           />
         </v-col>
-        <v-col cols="12" sm="3" md="2" class="pl-sm-2 mt-2 mt-sm-0">
+        <v-col cols="12" sm="6" md="4" class="pl-sm-2 mt-2 mt-sm-0">
           <v-text-field
             v-model="auditFilterIp"
             density="compact"
@@ -212,11 +207,6 @@
             hide-details
             @update:model-value="() => loadAudit()"
           />
-        </v-col>
-        <v-col class="d-flex justify-end mt-2 mt-sm-0 pl-sm-2">
-          <v-btn variant="tonal" color="primary" prepend-icon="mdi-magnify" @click="loadAudit">
-            Search
-          </v-btn>
         </v-col>
       </v-row>
 
@@ -461,8 +451,12 @@ function encodeRsql(v: string) {
 function buildActiveFilter(): string | undefined {
   const parts: string[] = ['status==ACTIVE']
   if (filterUser.value.trim()) {
-    const q = encodeRsql(filterUser.value.trim())
-    parts.push(`profile.email=ilike=*${q}*`)
+    const terms = filterUser.value.trim().split(/\s+/)
+    const termFilters = terms.map(term => {
+      const q = encodeRsql(term)
+      return `(profile.email=ilike="${q}",profile.forename=ilike="${q}",profile.surname=ilike="${q}")`
+    })
+    parts.push(termFilters.length === 1 ? termFilters[0]! : `(${termFilters.join(';')})`)
   }
   if (filterIp.value.trim()) {
     parts.push(`clientIp==${encodeRsql(filterIp.value.trim())}`)
@@ -482,8 +476,12 @@ function buildActiveFilter(): string | undefined {
 function buildAuditFilter(): string | undefined {
   const parts: string[] = ['status==REVOKED']
   if (auditFilterUser.value.trim()) {
-    const q = encodeRsql(auditFilterUser.value.trim())
-    parts.push(`profile.email=ilike=*${q}*`)
+    const terms = auditFilterUser.value.trim().split(/\s+/)
+    const termFilters = terms.map(term => {
+      const q = encodeRsql(term)
+      return `(profile.email=ilike="${q}",profile.forename=ilike="${q}",profile.surname=ilike="${q}")`
+    })
+    parts.push(termFilters.length === 1 ? termFilters[0]! : `(${termFilters.join(';')})`)
   }
   if (auditFilterIp.value.trim()) {
     parts.push(`clientIp==${encodeRsql(auditFilterIp.value.trim())}`)

--- a/src/main/webapp/src/views/admin/SecurityView.vue
+++ b/src/main/webapp/src/views/admin/SecurityView.vue
@@ -83,11 +83,9 @@
         >
           <!-- User column -->
           <template #item.user="{ item }">
-            <div class="d-flex align-center gap-2 py-1">
-              <v-avatar size="28" color="primary" class="text-caption font-weight-bold">
-                {{ userInitial(item) }}
-              </v-avatar>
-              <div>
+            <div class="d-flex align-center py-1">
+              <UserAvatar :email="item.userEmail" :size="28" />
+              <div class="ml-3">
                 <div class="text-body-2 font-weight-medium">{{ userFullName(item) }}</div>
                 <div class="text-caption text-medium-emphasis">{{ item.userEmail ?? '—' }}</div>
               </div>
@@ -98,7 +96,13 @@
           <template #item.clientIp="{ item }">
             <div>
               <div class="text-body-2">{{ item.clientIp ?? '—' }}</div>
-              <div class="text-caption text-medium-emphasis">{{ item.clientGeo ?? '' }}</div>
+              <v-tooltip location="top" max-width="360" :text="item.clientGeo ?? ''">
+                <template #activator="{ props }">
+                  <div v-bind="props" class="text-caption text-medium-emphasis text-no-wrap text-truncate" style="max-width: 220px">
+                    {{ item.clientGeo ?? '' }}
+                  </div>
+                </template>
+              </v-tooltip>
             </div>
           </template>
 
@@ -109,6 +113,7 @@
                 :icon="item.isMobile ? 'mdi-cellphone' : 'mdi-monitor'"
                 size="16"
                 color="medium-emphasis"
+                class="mx-1"
               />
               <div>
                 <div class="text-body-2">{{ item.browser ?? '—' }}</div>
@@ -119,41 +124,51 @@
 
           <!-- Login time -->
           <template #item.loginAt="{ item }">
-            {{ item.loginAt ? formatDateTime(item.loginAt) : '—' }}
+            <div v-if="item.loginAt">
+              <div class="text-body-2">{{ formatDate(item.loginAt) }}</div>
+              <div class="text-caption text-medium-emphasis">{{ formatTime(item.loginAt) }}</div>
+            </div>
+            <span v-else>—</span>
           </template>
 
           <!-- Last active -->
           <template #item.lastActiveAt="{ item }">
-            {{ item.lastActiveAt ? formatDateTime(item.lastActiveAt) : '—' }}
+            <div v-if="item.lastActiveAt">
+              <div class="text-body-2">{{ formatDate(item.lastActiveAt) }}</div>
+              <div class="text-caption text-medium-emphasis">{{ formatTime(item.lastActiveAt) }}</div>
+            </div>
+            <span v-else>—</span>
           </template>
 
           <!-- Actions -->
           <template #item.actions="{ item }">
-            <v-btn
-              size="small"
-              variant="text"
-              icon="mdi-logout"
-              title="Revoke session"
-              color="error"
-              @click="confirmRevoke(item)"
-            />
-            <v-menu>
-              <template #activator="{ props }">
-                <v-btn size="small" variant="text" icon="mdi-dots-vertical" v-bind="props" />
-              </template>
-              <v-list density="compact" min-width="220">
-                <v-list-item
-                  prepend-icon="mdi-account-cancel-outline"
-                  title="Revoke all sessions for this user"
-                  @click="confirmBulkByUser(item)"
-                />
-                <v-list-item
-                  prepend-icon="mdi-ip-network-outline"
-                  title="Revoke all sessions from this IP"
-                  @click="confirmBulkByIp(item)"
-                />
-              </v-list>
-            </v-menu>
+            <div class="d-flex align-center ga-1 text-no-wrap">
+              <v-btn
+                size="small"
+                variant="text"
+                icon="mdi-logout"
+                title="Revoke session"
+                color="error"
+                @click="confirmRevoke(item)"
+              />
+              <v-menu>
+                <template #activator="{ props }">
+                  <v-btn size="small" variant="text" icon="mdi-dots-vertical" v-bind="props" />
+                </template>
+                <v-list density="compact" min-width="220">
+                  <v-list-item
+                    prepend-icon="mdi-account-cancel-outline"
+                    title="Revoke all sessions for this user"
+                    @click="confirmBulkByUser(item)"
+                  />
+                  <v-list-item
+                    prepend-icon="mdi-ip-network-outline"
+                    title="Revoke all sessions from this IP"
+                    @click="confirmBulkByIp(item)"
+                  />
+                </v-list>
+              </v-menu>
+            </div>
           </template>
 
           <!-- Empty -->
@@ -223,11 +238,9 @@
         >
           <!-- User -->
           <template #item.user="{ item }">
-            <div class="d-flex align-center gap-2 py-1">
-              <v-avatar size="28" color="grey" class="text-caption font-weight-bold">
-                {{ userInitial(item) }}
-              </v-avatar>
-              <div>
+            <div class="d-flex align-center py-1">
+              <UserAvatar :email="item.userEmail" :size="28" />
+              <div class="ml-3">
                 <div class="text-body-2 font-weight-medium">{{ userFullName(item) }}</div>
                 <div class="text-caption text-medium-emphasis">{{ item.userEmail ?? '—' }}</div>
               </div>
@@ -238,7 +251,13 @@
           <template #item.clientIp="{ item }">
             <div>
               <div class="text-body-2">{{ item.clientIp ?? '—' }}</div>
-              <div class="text-caption text-medium-emphasis">{{ item.clientGeo ?? '' }}</div>
+              <v-tooltip location="top" max-width="360" :text="item.clientGeo ?? ''">
+                <template #activator="{ props }">
+                  <div v-bind="props" class="text-caption text-medium-emphasis text-no-wrap text-truncate" style="max-width: 220px">
+                    {{ item.clientGeo ?? '' }}
+                  </div>
+                </template>
+              </v-tooltip>
             </div>
           </template>
 
@@ -249,6 +268,7 @@
                 :icon="item.isMobile ? 'mdi-cellphone' : 'mdi-monitor'"
                 size="16"
                 color="medium-emphasis"
+                class="mx-1"
               />
               <span class="text-body-2">{{ item.browser ?? '—' }} / {{ item.os ?? '—' }}</span>
             </div>
@@ -263,7 +283,11 @@
 
           <!-- Revoked at -->
           <template #item.revokedAt="{ item }">
-            {{ item.revokedAt ? formatDateTime(item.revokedAt) : '—' }}
+            <div v-if="item.revokedAt">
+              <div class="text-body-2">{{ formatDate(item.revokedAt) }}</div>
+              <div class="text-caption text-medium-emphasis">{{ formatTime(item.revokedAt) }}</div>
+            </div>
+            <span v-else>—</span>
           </template>
 
           <!-- Empty -->
@@ -297,6 +321,7 @@ import { useToastStore } from '../../stores/toast'
 import AdminSessionService from '../../services/admin/admin-session.service'
 import type { IAdminSessionListItem } from '../../models'
 import ConfirmDialog from '../../components/ConfirmDialog.vue'
+import UserAvatar from '../../components/UserAvatar.vue'
 
 const toast = useToastStore()
 const service = new AdminSessionService()
@@ -403,17 +428,16 @@ function userFullName(item: IAdminSessionListItem) {
   return [item.userForename, item.userSurname].filter(Boolean).join(' ') || item.userEmail || '—'
 }
 
-function userInitial(item: IAdminSessionListItem) {
-  const f = item.userForename?.[0] ?? ''
-  const s = item.userSurname?.[0] ?? ''
-  return (f + s).toUpperCase() || (item.userEmail?.[0] ?? '?').toUpperCase()
-}
-
-function formatDateTime(iso: string) {
-  return new Date(iso).toLocaleString(undefined, {
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString(undefined, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
+  })
+}
+
+function formatTime(iso: string) {
+  return new Date(iso).toLocaleTimeString(undefined, {
     hour: '2-digit',
     minute: '2-digit',
   })


### PR DESCRIPTION
## Phase 2 — UI Polish

### Changes in `SecurityView.vue`:

- **UserAvatar component** — replaced manual `<v-avatar>` initials with Gravatar via `UserAvatar` on both tabs
- **Avatar spacing** — aligned with `UsersView.vue` pattern (`ml-3` instead of `gap-2`)
- **Device icon margin** — added `class="mx-1"` for consistent spacing on both tabs
- **Action buttons single-line** — wrapped revoke + menu in `<div class="d-flex align-center ga-1 text-no-wrap">` (Live Sessions tab)
- **IP/Location tooltip** — replaced plain second line with `v-tooltip` + `text-truncate text-no-wrap` on both tabs
- **Date/Time split** — replaced single `formatDateTime()` with `formatDate()` + `formatTime()`, showing date on top row, time on bottom row for all three date columns
- **Removed** unused `userInitial()` helper

Closes Phase 2 of the Security View Enhancement plan.