### PR TITLE
fix(auth): constrain form width to prevent stretching on mid-size screens

### DIFF
--- a/src/main/webapp/src/views/auth/EmailConfirmationView.vue
+++ b/src/main/webapp/src/views/auth/EmailConfirmationView.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="d-flex align-center justify-center" fluid style="min-height: 100vh">
     <v-row align="center" justify="center" class="w-100">
-      <v-col cols="12" sm="8" md="5" lg="4">
+      <v-col cols="12" sm="8" md="5" lg="4" style="max-width: 500px; width: 100%">
         <v-card rounded="lg" elevation="8">
           <v-card-text class="text-center pt-6 pb-0">
             <AppLogo />

--- a/src/main/webapp/src/views/auth/ForgotPasswordView.vue
+++ b/src/main/webapp/src/views/auth/ForgotPasswordView.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="d-flex align-center justify-center" fluid style="min-height: 100vh">
     <v-row align="center" justify="center" class="w-100">
-      <v-col cols="12" sm="8" md="5" lg="4">
+      <v-col cols="12" sm="8" md="5" lg="4" style="max-width: 500px; width: 100%">
         <v-card rounded="lg" elevation="8">
           <v-card-text class="text-center pt-6 pb-0">
             <AppLogo />

--- a/src/main/webapp/src/views/auth/LoginView.vue
+++ b/src/main/webapp/src/views/auth/LoginView.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="d-flex align-center justify-center" fluid style="min-height: 100vh">
     <v-row align="center" justify="center" class="w-100">
-      <v-col cols="12" sm="8" md="5" lg="4">
+      <v-col cols="12" sm="8" md="5" lg="4" style="max-width: 500px; width: 100%">
         <v-card rounded="lg" elevation="8">
           <v-card-text class="text-center pt-6 pb-0">
             <AppLogo />

--- a/src/main/webapp/src/views/auth/RegisterView.vue
+++ b/src/main/webapp/src/views/auth/RegisterView.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="d-flex align-center justify-center" fluid style="min-height: 100vh">
     <v-row align="center" justify="center" class="w-100">
-      <v-col cols="12" sm="8" md="6" lg="5">
+      <v-col cols="12" sm="8" md="6" lg="5" style="max-width: 560px; width: 100%">
         <v-card rounded="lg" elevation="8">
           <v-card-text class="text-center pt-6 pb-0">
             <AppLogo />

--- a/src/main/webapp/src/views/auth/ResetPasswordView.vue
+++ b/src/main/webapp/src/views/auth/ResetPasswordView.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="d-flex align-center justify-center" fluid style="min-height: 100vh">
     <v-row align="center" justify="center" class="w-100">
-      <v-col cols="12" sm="8" md="5" lg="4">
+      <v-col cols="12" sm="8" md="5" lg="4" style="max-width: 500px; width: 100%">
         <v-card rounded="lg" elevation="8">
           <v-card-text class="text-center pt-6 pb-0">
             <AppLogo />


### PR DESCRIPTION
Auth forms stretch too wide at certain breakpoints because the `v-col` width is percentage-based with no upper bound. Added `max-width: 500px` (560px for Register) with `width: 100%` to the card wrapper column so forms stay compact on all screen sizes.

**Pages updated:**
- LoginView
- RegisterView
- ForgotPasswordView
- ResetPasswordView
- EmailConfirmationView