### PR TITLE
fix: guard null profile in ResumeTab and hoist fetchResumeInfo before watch

### DIFF
--- a/src/main/webapp/src/components/profile/ProfileResumeField.vue
+++ b/src/main/webapp/src/components/profile/ProfileResumeField.vue
@@ -149,6 +149,19 @@ const downloading = ref(false)
 const deleting = ref(false)
 const showDeleteDialog = ref(false)
 
+// Methods
+const fetchResumeInfo = async (resumeId: string) => {
+  loading.value = true
+  try {
+    resumeInfo.value = await resumeService.find(resumeId)
+  } catch (error) {
+    console.error('Failed to fetch resume info:', error)
+    resumeInfo.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
 // Fetch resume info when resumeId changes
 watch(
   () => props.resumeId,
@@ -167,19 +180,6 @@ onMounted(async () => {
     await fetchResumeInfo(props.resumeId)
   }
 })
-
-// Methods
-const fetchResumeInfo = async (resumeId: string) => {
-  loading.value = true
-  try {
-    resumeInfo.value = await resumeService.find(resumeId)
-  } catch (error) {
-    console.error('Failed to fetch resume info:', error)
-    resumeInfo.value = null
-  } finally {
-    loading.value = false
-  }
-}
 
 const handleAddFile = async (_error: FilePondErrorDescription | null, file: FilePondFile) => {
   if (_error) {

--- a/src/main/webapp/src/components/profile/resume/ResumeTab.vue
+++ b/src/main/webapp/src/components/profile/resume/ResumeTab.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="profile">
     <ContactSectionCard :profile="profile" @update="onContactUpdate" />
     <SummaryCard :profile="profile" @update="onContactUpdate" />
     <ResumeFileCard
@@ -73,6 +73,10 @@
       @save="onSaveAllExtracted"
       @cancel="showPreview = false"
     />
+  </div>
+  <div v-else class="text-center py-8 text-medium-emphasis">
+    <v-icon icon="mdi-file-account-off" size="48" class="mb-2" />
+    <p>Unable to load resume data.</p>
   </div>
 </template>
 


### PR DESCRIPTION
Fixes two runtime errors on the Profile page:

1. **ResumeTab.vue** — `profile.id` accessed on null when `ResumeTab` mounts before async `loadProfile()` completes. Added `v-if="profile"` guard with fallback message (consistent with `ProfileInfoCard.vue` pattern).

2. **ProfileResumeField.vue** — `ReferenceError: Cannot access 'fetchResumeInfo' before initialization` because `const` arrow functions are not hoisted in `<script setup>`. Moved `fetchResumeInfo` definition above the `watch` that references it with `{ immediate: true }`.