### PR TITLE
feat: profile info enhancement — avatar upload, merged profile form, resume tab cleanup

### DIFF
--- a/src/main/kotlin/com/glinboy/opportune/repository/ProfileRepository.kt
+++ b/src/main/kotlin/com/glinboy/opportune/repository/ProfileRepository.kt
@@ -33,6 +33,10 @@ interface ProfileRepository : JpaRepository<Profile, UUID>, JpaSpecificationExec
 	@Query("UPDATE Profile p SET p.password = :password WHERE p.id = :id")
 	fun updatePassword(id: UUID, password: String)
 
+	@Modifying
+	@Query("UPDATE Profile p SET p.avatar = :avatar WHERE p.id = :id")
+	fun updateAvatar(@Param("id") id: UUID, @Param("avatar") avatar: String?)
+
 	@Query("SELECT p.status AS status, COUNT(p) AS total FROM Profile p GROUP BY p.status")
 	fun countByStatusGrouped(): List<ProfileStatusCountProjection>
 

--- a/src/main/kotlin/com/glinboy/opportune/service/FileService.kt
+++ b/src/main/kotlin/com/glinboy/opportune/service/FileService.kt
@@ -2,12 +2,16 @@ package com.glinboy.opportune.service
 
 import org.springframework.core.io.Resource
 import org.springframework.web.multipart.MultipartFile
+import java.util.*
 
 interface FileService {
 	fun upload()
 	fun download()
 	fun delete()
 	fun uploadResume(file: MultipartFile): String
+	fun uploadAvatar(profileId: UUID, file: MultipartFile): String
+	fun deleteAvatar(filePath: String)
+	fun getAvatar(path: String): Resource
 	fun uploadAttachment(file: MultipartFile, userId: String, noteId: String): String
 	fun loadFileAsResource(path: String): Resource
 	fun deleteFile(path: String)

--- a/src/main/kotlin/com/glinboy/opportune/service/FileService.kt
+++ b/src/main/kotlin/com/glinboy/opportune/service/FileService.kt
@@ -10,8 +10,8 @@ interface FileService {
 	fun delete()
 	fun uploadResume(file: MultipartFile): String
 	fun uploadAvatar(profileId: UUID, file: MultipartFile): String
-	fun deleteAvatar(filePath: String)
-	fun getAvatar(path: String): Resource
+	fun deleteAvatar(profileId: UUID, filename: String)
+	fun loadAvatar(profileId: UUID, filename: String): Resource
 	fun uploadAttachment(file: MultipartFile, userId: String, noteId: String): String
 	fun loadFileAsResource(path: String): Resource
 	fun deleteFile(path: String)

--- a/src/main/kotlin/com/glinboy/opportune/service/ProfileService.kt
+++ b/src/main/kotlin/com/glinboy/opportune/service/ProfileService.kt
@@ -17,4 +17,6 @@ interface ProfileService : GenericService<UUID, ProfileDTO>, UserDetailsService 
 	fun initiatePasswordReset(passwordResetInitiationRequestDTO: PasswordResetInitiationRequestDTO)
 	fun finalizePasswordReset(passwordResetFinalizationRequestDTO: PasswordResetFinalizationRequestDTO)
 	fun changePassword(passwordUpdateRequestDTO: PasswordUpdateRequestDTO)
+	fun updateAvatarPath(id: UUID, path: String?)
+	fun clearAvatarPath(id: UUID)
 }

--- a/src/main/kotlin/com/glinboy/opportune/service/impl/LocalFileService.kt
+++ b/src/main/kotlin/com/glinboy/opportune/service/impl/LocalFileService.kt
@@ -48,6 +48,29 @@ class LocalFileService(private val properties: ApplicationProperties) : FileServ
 		return targetPath.toString()
 	}
 
+	override fun uploadAvatar(profileId: UUID, file: MultipartFile): String {
+		val avatarDir = Paths.get(properties.files.basePath, profileId.toString(), "avatars")
+
+		if (!Files.exists(avatarDir)) {
+			Files.createDirectories(avatarDir)
+		}
+
+		val originalFilename = file.originalFilename ?: "avatar"
+		val extension = originalFilename.substringAfterLast('.', "")
+		val newFilename = "${UUID.randomUUID()}${if (extension.isNotEmpty()) ".$extension" else ""}"
+		val targetPath: Path = avatarDir.resolve(newFilename)
+
+		Files.copy(file.inputStream, targetPath, StandardCopyOption.REPLACE_EXISTING)
+
+		return targetPath.toString()
+	}
+
+	override fun deleteAvatar(filePath: String) {
+		deleteFile(filePath)
+	}
+
+	override fun getAvatar(path: String): Resource = loadFileAsResource(path)
+
 	override fun uploadAttachment(file: MultipartFile, userId: String, noteId: String): String {
 		val attachmentPath = Paths.get(properties.files.basePath, userId, "interview-notes", noteId)
 

--- a/src/main/kotlin/com/glinboy/opportune/service/impl/LocalFileService.kt
+++ b/src/main/kotlin/com/glinboy/opportune/service/impl/LocalFileService.kt
@@ -55,21 +55,29 @@ class LocalFileService(private val properties: ApplicationProperties) : FileServ
 			Files.createDirectories(avatarDir)
 		}
 
-		val originalFilename = file.originalFilename ?: "avatar"
+		val originalFilename = file.originalFilename ?: "avatar.jpg"
 		val extension = originalFilename.substringAfterLast('.', "")
-		val newFilename = "${UUID.randomUUID()}${if (extension.isNotEmpty()) ".$extension" else ""}"
-		val targetPath: Path = avatarDir.resolve(newFilename)
+		val filename = "avatar.${extension}"
+		val targetPath: Path = avatarDir.resolve(filename)
 
 		Files.copy(file.inputStream, targetPath, StandardCopyOption.REPLACE_EXISTING)
 
-		return targetPath.toString()
+		return filename
 	}
 
-	override fun deleteAvatar(filePath: String) {
-		deleteFile(filePath)
+	override fun deleteAvatar(profileId: UUID, filename: String) {
+		val filePath = Paths.get(properties.files.basePath, profileId.toString(), "avatars", filename)
+		Files.deleteIfExists(filePath)
 	}
 
-	override fun getAvatar(path: String): Resource = loadFileAsResource(path)
+	override fun loadAvatar(profileId: UUID, filename: String): Resource {
+		val filePath = Paths.get(properties.files.basePath, profileId.toString(), "avatars", filename)
+		val resource = UrlResource(filePath.toUri())
+		if (resource.exists() && resource.isReadable) {
+			return resource
+		}
+		throw ResponseStatusException(HttpStatus.NOT_FOUND, "Avatar not found")
+	}
 
 	override fun uploadAttachment(file: MultipartFile, userId: String, noteId: String): String {
 		val attachmentPath = Paths.get(properties.files.basePath, userId, "interview-notes", noteId)

--- a/src/main/kotlin/com/glinboy/opportune/service/impl/ProfileServiceImpl.kt
+++ b/src/main/kotlin/com/glinboy/opportune/service/impl/ProfileServiceImpl.kt
@@ -171,6 +171,16 @@ class ProfileServiceImpl(
 	}
 
 	@Transactional
+	override fun updateAvatarPath(id: UUID, path: String?) {
+		repository.updateAvatar(id, path)
+	}
+
+	@Transactional
+	override fun clearAvatarPath(id: UUID) {
+		repository.updateAvatar(id, null)
+	}
+
+	@Transactional
 	override fun changePassword(passwordUpdateRequestDTO: PasswordUpdateRequestDTO) {
 		val currentUserId = UUID.fromString(SecurityUtils.getCurrentUserLogin())
 		SecurityUtils.getCurrentUserLogin()

--- a/src/main/kotlin/com/glinboy/opportune/web/rest/AdminUserResource.kt
+++ b/src/main/kotlin/com/glinboy/opportune/web/rest/AdminUserResource.kt
@@ -6,26 +6,37 @@ import com.glinboy.opportune.dto.AdminUserListItemDTO
 import com.glinboy.opportune.dto.AdminUserRoleUpdateDTO
 import com.glinboy.opportune.dto.AdminUserStatusUpdateDTO
 import com.glinboy.opportune.dto.ProfileDTO
+import com.glinboy.opportune.repository.ProfileRepository
 import com.glinboy.opportune.service.AdminUserService
+import com.glinboy.opportune.service.FileService
 import com.glinboy.opportune.util.PaginationUtil
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springdoc.core.converters.models.PageableAsQueryParam
+import org.springframework.core.io.Resource
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.annotation.Secured
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.server.ResponseStatusException
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.*
 
 @RestController
 @Secured("ROLE_ADMIN")
 @RequestMapping("/api/admin/users")
 @SecurityRequirement(name = OpenApiConfiguration.BEARER_AUTHENTICATION_NAME)
-class AdminUserResource(private val adminUserService: AdminUserService) {
+class AdminUserResource(
+	private val adminUserService: AdminUserService,
+	private val profileRepository: ProfileRepository,
+	private val fileService: FileService
+) {
 
 	@GetMapping
 	@PageableAsQueryParam
@@ -68,5 +79,22 @@ class AdminUserResource(private val adminUserService: AdminUserService) {
 	fun deleteUser(@PathVariable id: UUID): ResponseEntity<Void> {
 		adminUserService.deleteUser(id)
 		return ResponseEntity.noContent().build()
+	}
+
+	@GetMapping("/{profileId}/avatar")
+	fun getAvatar(@PathVariable profileId: UUID): ResponseEntity<Resource> {
+		val profile = profileRepository.findById(profileId)
+			.orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND, "Profile not found") }
+		val filename = profile.avatar
+			?: return ResponseEntity.notFound().build()
+		val resource = fileService.loadAvatar(profileId, filename)
+		val contentType = try {
+			Files.probeContentType(Path.of(filename)) ?: MediaType.APPLICATION_OCTET_STREAM_VALUE
+		} catch (e: Exception) {
+			MediaType.APPLICATION_OCTET_STREAM_VALUE
+		}
+		return ResponseEntity.ok()
+			.contentType(MediaType.parseMediaType(contentType))
+			.body(resource)
 	}
 }

--- a/src/main/kotlin/com/glinboy/opportune/web/rest/ProfileResource.kt
+++ b/src/main/kotlin/com/glinboy/opportune/web/rest/ProfileResource.kt
@@ -4,6 +4,9 @@ import com.glinboy.opportune.config.OpenApiConfiguration
 import com.glinboy.opportune.dto.PasswordUpdateRequestDTO
 import com.glinboy.opportune.dto.ProfileDTO
 import com.glinboy.opportune.dto.SessionDTO
+import com.glinboy.opportune.repository.ProfileRepository
+import com.glinboy.opportune.security.SecurityUtils
+import com.glinboy.opportune.service.FileService
 import com.glinboy.opportune.service.ProfileService
 import com.glinboy.opportune.service.SessionService
 import com.glinboy.opportune.util.PaginationUtil
@@ -15,15 +18,25 @@ import org.springdoc.core.converters.models.PageableAsQueryParam
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+import org.springframework.core.io.Resource
+import org.springframework.web.server.ResponseStatusException
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.*
 
 @RestController
 @RequestMapping("/api/profiles")
 @SecurityRequirement(name = OpenApiConfiguration.BEARER_AUTHENTICATION_NAME)
-class ProfileResource(profileService: ProfileService, private val sessionService: SessionService) :
-	GenericResource<UUID, ProfileDTO, ProfileService>(profileService) {
+class ProfileResource(
+	profileService: ProfileService,
+	private val sessionService: SessionService,
+	private val fileService: FileService,
+	private val profileRepository: ProfileRepository
+) : GenericResource<UUID, ProfileDTO, ProfileService>(profileService) {
 
 	@GetMapping("/me")
 	fun getCurrentProfile(): ResponseEntity<ProfileDTO>? =
@@ -66,6 +79,44 @@ class ProfileResource(profileService: ProfileService, private val sessionService
 	fun confirmEmail(@RequestParam code: String): ResponseEntity<Unit> {
 			service.confirmEmail(code)
 			return ResponseEntity.ok().build()
+	}
+
+	@PostMapping("/avatar", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+	fun uploadAvatar(@RequestParam("avatar") file: MultipartFile): ResponseEntity<Map<String, String>> {
+		val currentUserId = SecurityUtils.getCurrentUserLoginID()
+		val filePath = fileService.uploadAvatar(currentUserId, file)
+		profileRepository.updateAvatar(currentUserId, filePath)
+		return ResponseEntity.ok(mapOf("avatarPath" to filePath))
+	}
+
+	@DeleteMapping("/avatar")
+	fun deleteAvatar(): ResponseEntity<Unit> {
+		val currentUserId = SecurityUtils.getCurrentUserLoginID()
+		val profile = profileRepository.findById(currentUserId)
+			.orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND, "Profile not found") }
+		profile.avatar?.let { avatarPath ->
+			fileService.deleteAvatar(avatarPath)
+			profileRepository.updateAvatar(currentUserId, null)
+		}
+		return ResponseEntity.noContent().build()
+	}
+
+	@GetMapping("/avatar")
+	fun getAvatar(): ResponseEntity<Resource> {
+		val currentUserId = SecurityUtils.getCurrentUserLoginID()
+		val profile = profileRepository.findById(currentUserId)
+			.orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND, "Profile not found") }
+		val avatarPath = profile.avatar
+			?: return ResponseEntity.notFound().build()
+		val resource = fileService.getAvatar(avatarPath)
+		val contentType = try {
+			Files.probeContentType(Path.of(avatarPath)) ?: MediaType.APPLICATION_OCTET_STREAM_VALUE
+		} catch (e: Exception) {
+			MediaType.APPLICATION_OCTET_STREAM_VALUE
+		}
+		return ResponseEntity.ok()
+			.contentType(MediaType.parseMediaType(contentType))
+			.body(resource)
 	}
 }
 

--- a/src/main/kotlin/com/glinboy/opportune/web/rest/ProfileResource.kt
+++ b/src/main/kotlin/com/glinboy/opportune/web/rest/ProfileResource.kt
@@ -84,9 +84,9 @@ class ProfileResource(
 	@PostMapping("/avatar", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
 	fun uploadAvatar(@RequestParam("avatar") file: MultipartFile): ResponseEntity<Map<String, String>> {
 		val currentUserId = SecurityUtils.getCurrentUserLoginID()
-		val filePath = fileService.uploadAvatar(currentUserId, file)
-		profileRepository.updateAvatar(currentUserId, filePath)
-		return ResponseEntity.ok(mapOf("avatarPath" to filePath))
+		val filename = fileService.uploadAvatar(currentUserId, file)
+		service.updateAvatarPath(currentUserId, filename)
+		return ResponseEntity.ok(mapOf("avatarPath" to filename))
 	}
 
 	@DeleteMapping("/avatar")
@@ -94,9 +94,9 @@ class ProfileResource(
 		val currentUserId = SecurityUtils.getCurrentUserLoginID()
 		val profile = profileRepository.findById(currentUserId)
 			.orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND, "Profile not found") }
-		profile.avatar?.let { avatarPath ->
-			fileService.deleteAvatar(avatarPath)
-			profileRepository.updateAvatar(currentUserId, null)
+		profile.avatar?.let { filename ->
+			fileService.deleteAvatar(currentUserId, filename)
+			service.clearAvatarPath(currentUserId)
 		}
 		return ResponseEntity.noContent().build()
 	}
@@ -106,11 +106,11 @@ class ProfileResource(
 		val currentUserId = SecurityUtils.getCurrentUserLoginID()
 		val profile = profileRepository.findById(currentUserId)
 			.orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND, "Profile not found") }
-		val avatarPath = profile.avatar
+		val filename = profile.avatar
 			?: return ResponseEntity.notFound().build()
-		val resource = fileService.getAvatar(avatarPath)
+		val resource = fileService.loadAvatar(currentUserId, filename)
 		val contentType = try {
-			Files.probeContentType(Path.of(avatarPath)) ?: MediaType.APPLICATION_OCTET_STREAM_VALUE
+			Files.probeContentType(Path.of(filename)) ?: MediaType.APPLICATION_OCTET_STREAM_VALUE
 		} catch (e: Exception) {
 			MediaType.APPLICATION_OCTET_STREAM_VALUE
 		}

--- a/src/main/webapp/src/components/UserAvatar.vue
+++ b/src/main/webapp/src/components/UserAvatar.vue
@@ -3,18 +3,53 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
 import CryptoJS from 'crypto-js'
+import apiClient from '@/services/api'
 
 const props = defineProps<{
   email?: string
   avatarUrl?: string
   size?: number
+  profileId?: string
 }>()
+
+const avatarBlobUrl = ref('')
+
+const fetchAvatarBlob = async () => {
+  if (avatarBlobUrl.value) {
+    URL.revokeObjectURL(avatarBlobUrl.value)
+    avatarBlobUrl.value = ''
+  }
+  if (props.avatarUrl && !props.avatarUrl.startsWith('http')) {
+    try {
+      const endpoint = props.profileId
+        ? `/api/admin/users/${props.profileId}/avatar`
+        : '/api/profiles/avatar'
+      const response = await apiClient.get(endpoint, { responseType: 'blob' })
+      avatarBlobUrl.value = URL.createObjectURL(response.data)
+    } catch {
+      // Fall through to Gravatar fallback
+    }
+  }
+}
+
+watch(() => props.avatarUrl, fetchAvatarBlob)
+onMounted(fetchAvatarBlob)
+onUnmounted(() => {
+  if (avatarBlobUrl.value) {
+    URL.revokeObjectURL(avatarBlobUrl.value)
+  }
+})
 
 const displayUrl = computed(() => {
   if (props.avatarUrl) {
-    return props.avatarUrl
+    if (props.avatarUrl.startsWith('http')) {
+      return props.avatarUrl
+    }
+    if (avatarBlobUrl.value) {
+      return avatarBlobUrl.value
+    }
   }
   const email = (props.email ?? '').trim().toLowerCase()
   if (!email) return ''

--- a/src/main/webapp/src/components/profile-menu/ProfileMenuAuthenticated.vue
+++ b/src/main/webapp/src/components/profile-menu/ProfileMenuAuthenticated.vue
@@ -3,13 +3,13 @@
     <v-menu min-width="200px" rounded transition="scale-y-transition" location="bottom right">
       <template v-slot:activator="{ props }">
         <v-btn icon v-bind="props">
-          <UserAvatar :email="userEmail" :size="32" />
+          <UserAvatar :email="userEmail" :avatar-url="profile?.avatar" :size="32" />
         </v-btn>
       </template>
       <v-card class="px-5">
         <v-card-text>
           <div class="mx-auto text-center">
-            <UserAvatar :email="userEmail" :size="48" class="my-2" />
+            <UserAvatar :email="userEmail" :avatar-url="profile?.avatar" :size="48" class="my-2" />
             <h3>{{ fullname }}</h3>
             <p class="text-caption mt-1">{{ userEmail }}</p>
             <v-divider class="my-3"></v-divider>

--- a/src/main/webapp/src/components/profile/ProfileForm.vue
+++ b/src/main/webapp/src/components/profile/ProfileForm.vue
@@ -1,202 +1,199 @@
 <template>
-  <div>
-    <v-form>
-      <v-row>
-        <!-- Avatar Section -->
-        <v-col cols="12" md="4">
-          <FormCard :collapsible="false">
-            <template #title>
-              <v-icon icon="mdi-account-circle" class="mr-2" />
-              Avatar
+  <v-form>
+    <v-row>
+      <!-- Row 1: Avatar + Name/Email -->
+      <v-col cols="12" md="4" class="d-flex flex-column align-center">
+        <div style="position: relative; display: inline-block;">
+          <v-avatar
+            size="120"
+            class="cursor-pointer"
+            @click="triggerFileInput"
+          >
+            <v-img :src="avatarUrl" :alt="fullName" />
+            <v-overlay
+              v-if="uploadingAvatar"
+              absolute
+              class="align-center justify-center"
+              contained
+            >
+              <v-progress-circular indeterminate size="28" color="primary" />
+            </v-overlay>
+          </v-avatar>
+
+          <v-tooltip v-if="avatarSource" :text="avatarSource.tooltip" location="bottom">
+            <template #activator="{ props }">
+              <v-icon
+                v-bind="props"
+                :icon="avatarSource.icon"
+                size="x-small"
+                color="primary"
+                class="position-absolute"
+                style="bottom: -2px; right: -2px; background: rgb(var(--v-theme-surface)); border-radius: 50%; padding: 2px;"
+              />
             </template>
+          </v-tooltip>
 
-            <template #default>
-              <div class="d-flex flex-column align-center">
-                <v-avatar size="80" class="mb-4">
-                  <v-img :src="avatarUrl" :alt="fullName" />
-                </v-avatar>
-
-                <div class="w-100">
-                  <v-file-input
-                    v-model="avatarFile"
-                    label="Upload Avatar"
-                    variant="outlined"
-                    prepend-inner-icon="mdi-camera"
-                    accept="image/*"
-                    density="compact"
-                    :loading="uploadingAvatar"
-                    clearable
-                    @update:model-value="handleAvatarUpload"
-                  />
-
-                  <div class="d-flex align-center mt-2">
-                    <v-btn
-                      v-if="!isUsingGravatar"
-                      color="primary"
-                      variant="text"
-                      size="small"
-                      prepend-icon="mdi-web"
-                      @click="useGravatar"
-                    >
-                      Use Gravatar
-                    </v-btn>
-                    <v-spacer />
-                    <p class="text-caption text-medium-emphasis ma-0">
-                      {{
-                        isUsingGravatar
-                          ? 'Using Gravatar based on email'
-                          : 'Using custom uploaded image'
-                      }}
-                    </p>
-                  </div>
-
-                  <!-- Account Information -->
-                  <v-divider class="my-4" />
-                  <h4 class="text-subtitle-2 mb-3 d-flex align-center">
-                    <v-icon icon="mdi-cog" class="mr-2" size="small" />
-                    Account Information
-                  </h4>
-
-                  <v-select
-                    :model-value="modelValue.status"
-                    :items="statusOptions"
-                    label="Account Status"
-                    variant="outlined"
-                    prepend-inner-icon="mdi-account-check"
-                    density="compact"
-                    readonly
-                    class="mb-3"
-                  />
-
-                  <v-text-field
-                    :model-value="lastLoginFormatted"
-                    label="Last Login"
-                    variant="outlined"
-                    prepend-inner-icon="mdi-clock"
-                    density="compact"
-                    readonly
-                    class="mb-3"
-                  />
-
-                  <v-text-field
-                    :model-value="modelValue.subscription"
-                    label="Subscription Plan"
-                    variant="outlined"
-                    prepend-inner-icon="mdi-credit-card"
-                    density="compact"
-                    readonly
-                    class="mb-3"
-                  />
-
-                  <v-switch
-                    :model-value="modelValue.emailVerification"
-                    label="Email Verified"
-                    color="success"
-                    readonly
-                  />
-                </div>
-              </div>
+          <v-tooltip v-if="isUploadedAvatar" text="Remove avatar" location="top">
+            <template #activator="{ props }">
+              <v-icon
+                v-bind="props"
+                icon="mdi-close-circle"
+                size="small"
+                color="error"
+                class="position-absolute"
+                style="top: -6px; right: -6px; cursor: pointer; background: rgb(var(--v-theme-surface)); border-radius: 50%;"
+                @click.stop="handleRemoveAvatar"
+              />
             </template>
-          </FormCard>
-        </v-col>
+          </v-tooltip>
+        </div>
 
-        <!-- Personal Information -->
-        <v-col cols="12" md="8">
-          <FormCard :collapsible="false">
-            <template #title>
-              <v-icon icon="mdi-account-details" class="mr-2" />
-              Your Details
-            </template>
+        <p class="text-caption text-medium-emphasis mt-2">Click avatar to upload</p>
 
-            <template #default>
-              <v-row>
-                <v-col cols="12" md="6">
-                  <v-text-field
-                    :model-value="modelValue.forename"
-                    label="First Name"
-                    variant="outlined"
-                    prepend-inner-icon="mdi-account"
-                    :rules="[rules.required]"
-                    @update:model-value="updateField('forename', $event)"
-                  />
-                </v-col>
-                <v-col cols="12" md="6">
-                  <v-text-field
-                    :model-value="modelValue.surname"
-                    label="Last Name"
-                    variant="outlined"
-                    prepend-inner-icon="mdi-account"
-                    :rules="[rules.required]"
-                    @update:model-value="updateField('surname', $event)"
-                  />
-                </v-col>
-                <v-col cols="12">
-                  <v-text-field
-                    :model-value="modelValue.email"
-                    label="Email Address"
-                    variant="outlined"
-                    prepend-inner-icon="mdi-email"
-                    type="email"
-                    :rules="[rules.required, rules.email]"
-                    @update:model-value="updateField('email', $event)"
-                  />
-                </v-col>
-                <v-col cols="12" md="6">
-                  <v-text-field
-                    :model-value="modelValue.jobTitle"
-                    label="Job Title"
-                    variant="outlined"
-                    prepend-inner-icon="mdi-briefcase"
-                    placeholder="e.g., Senior Software Engineer"
-                    @update:model-value="updateField('jobTitle', $event)"
-                  />
-                </v-col>
-                <v-col cols="12" md="6">
-                  <v-text-field
-                    :model-value="modelValue.location"
-                    label="Location"
-                    variant="outlined"
-                    prepend-inner-icon="mdi-map-marker"
-                    placeholder="e.g., San Francisco, CA"
-                    @update:model-value="updateField('location', $event)"
-                  />
-                </v-col>
-                <v-col cols="12">
-                  <v-alert
-                    type="info"
-                    variant="tonal"
-                    icon="mdi-file-account"
-                    title="Resume & Structured Data"
-                    text="Upload and manage your resume, work experience, education, and skills in the dedicated Resume section."
-                    density="compact"
-                  >
-                    <template #append>
-                      <v-btn
-                        variant="text"
-                        color="primary"
-                        size="small"
-                        :to="{ name: 'profile-resume' }"
-                      >
-                        Go to Resume
-                      </v-btn>
-                    </template>
-                  </v-alert>
-                </v-col>
-              </v-row>
-            </template>
-          </FormCard>
-        </v-col>
-      </v-row>
-    </v-form>
-  </div>
+        <input
+          ref="fileInput"
+          type="file"
+          accept="image/*"
+          hidden
+          @change="handleFileSelected"
+        />
+      </v-col>
+
+      <v-col cols="12" md="8">
+        <v-row>
+          <v-col cols="12" md="6">
+            <v-text-field
+              :model-value="modelValue.forename"
+              label="First Name"
+              variant="outlined"
+              prepend-inner-icon="mdi-account"
+              :rules="[rules.required]"
+              @update:model-value="updateField('forename', $event)"
+            />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field
+              :model-value="modelValue.surname"
+              label="Last Name"
+              variant="outlined"
+              prepend-inner-icon="mdi-account"
+              :rules="[rules.required]"
+              @update:model-value="updateField('surname', $event)"
+            />
+          </v-col>
+          <v-col cols="12">
+            <v-text-field
+              :model-value="modelValue.email"
+              label="Email Address"
+              variant="outlined"
+              prepend-inner-icon="mdi-email"
+              type="email"
+              readonly
+              :rules="[rules.required, rules.email]"
+            >
+              <template #append-inner>
+                <v-tooltip
+                  :text="modelValue.emailVerification ? 'Email verified' : 'Email not verified'"
+                  location="top"
+                >
+                  <template #activator="{ props }">
+                    <v-icon
+                      v-bind="props"
+                      :icon="modelValue.emailVerification ? 'mdi-check-circle' : 'mdi-alert-circle-outline'"
+                      :color="modelValue.emailVerification ? 'success' : 'warning'"
+                    />
+                  </template>
+                </v-tooltip>
+              </template>
+            </v-text-field>
+          </v-col>
+        </v-row>
+      </v-col>
+    </v-row>
+
+    <!-- Row 2: Job Title + Location -->
+    <v-row>
+      <v-col cols="12" md="6">
+        <v-text-field
+          :model-value="modelValue.jobTitle"
+          label="Job Title"
+          variant="outlined"
+          prepend-inner-icon="mdi-briefcase"
+          placeholder="e.g., Senior Software Engineer"
+          @update:model-value="updateField('jobTitle', $event)"
+        />
+      </v-col>
+      <v-col cols="12" md="6">
+        <v-text-field
+          :model-value="modelValue.location"
+          label="Location"
+          variant="outlined"
+          prepend-inner-icon="mdi-map-marker"
+          placeholder="e.g., San Francisco, CA"
+          @update:model-value="updateField('location', $event)"
+        />
+      </v-col>
+    </v-row>
+
+    <!-- Row 3: Phone + LinkedIn + Portfolio -->
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-text-field
+          :model-value="modelValue.phone"
+          label="Phone"
+          variant="outlined"
+          prepend-inner-icon="mdi-phone"
+          placeholder="+1 (555) 123-4567"
+          @update:model-value="updateField('phone', $event)"
+        />
+      </v-col>
+      <v-col cols="12" md="4">
+        <v-text-field
+          :model-value="modelValue.linkedinUrl"
+          label="LinkedIn URL"
+          variant="outlined"
+          prepend-inner-icon="mdi-linkedin"
+          placeholder="https://linkedin.com/in/..."
+          @update:model-value="updateField('linkedinUrl', $event)"
+        />
+      </v-col>
+      <v-col cols="12" md="4">
+        <v-text-field
+          :model-value="modelValue.portfolioUrl"
+          label="Portfolio URL"
+          variant="outlined"
+          prepend-inner-icon="mdi-web"
+          placeholder="https://..."
+          @update:model-value="updateField('portfolioUrl', $event)"
+        />
+      </v-col>
+    </v-row>
+
+    <!-- Row 4: Professional Summary -->
+    <v-row>
+      <v-col cols="12">
+        <v-textarea
+          :model-value="modelValue.professionalSummary"
+          label="Professional Summary"
+          variant="outlined"
+          placeholder="Write a brief summary of your professional background, key achievements, and career goals..."
+          rows="5"
+          auto-grow
+          hint="This summary will be used by AI to tailor your cover letters and interview introductions."
+          persistent-hint
+          @update:model-value="updateField('professionalSummary', $event)"
+        />
+      </v-col>
+    </v-row>
+  </v-form>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
-import { type IProfile, ProfileStatus } from '../../models'
-import CryptoJS from 'crypto-js'
-import FormCard from '../forms/FormCard.vue'
-// import { AvatarService } from '../services' // Uncomment when avatar endpoint is ready
+import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
+import { type IProfile } from '../../models'
+import AvatarService from '../../services/avatar.service'
+import { useToastStore } from '../../stores/toast'
+import apiClient from '../../services/api'
 
 const props = defineProps<{
   modelValue: IProfile
@@ -207,11 +204,38 @@ const emit = defineEmits<{
   change: []
 }>()
 
-// Avatar upload state
-const avatarFile = ref<File[]>([])
-const uploadingAvatar = ref(false)
+const avatarService = new AvatarService()
+const toast = useToastStore()
 
-// Computed properties
+const fileInput = ref<HTMLInputElement | null>(null)
+const uploadingAvatar = ref(false)
+const avatarBlobUrl = ref('')
+
+const fetchAvatarBlob = async () => {
+  if (avatarBlobUrl.value) {
+    URL.revokeObjectURL(avatarBlobUrl.value)
+    avatarBlobUrl.value = ''
+  }
+  if (props.modelValue.avatar && !props.modelValue.avatar.startsWith('http')) {
+    try {
+      const response = await apiClient.get('/api/profiles/avatar', {
+        responseType: 'blob',
+      })
+      avatarBlobUrl.value = URL.createObjectURL(response.data)
+    } catch {
+      console.error('Failed to load avatar')
+    }
+  }
+}
+
+watch(() => props.modelValue.avatar, fetchAvatarBlob)
+onMounted(fetchAvatarBlob)
+onUnmounted(() => {
+  if (avatarBlobUrl.value) {
+    URL.revokeObjectURL(avatarBlobUrl.value)
+  }
+})
+
 const fullName = computed(() => {
   if (props.modelValue.forename && props.modelValue.surname) {
     return `${props.modelValue.forename} ${props.modelValue.surname}`
@@ -221,38 +245,31 @@ const fullName = computed(() => {
 
 const gravatarUrl = computed(() => {
   if (!props.modelValue.email) return ''
-
-  const trimmedEmail = props.modelValue.email.trim().toLowerCase()
-  const hash = CryptoJS.MD5(trimmedEmail).toString()
-  return `https://www.gravatar.com/avatar/${hash}?s=80&d=mp&r=g`
-})
-
-const isUsingGravatar = computed(() => {
-  return !props.modelValue.avatar || props.modelValue.avatar === gravatarUrl.value
+  return avatarService.getGravatarUrl(props.modelValue.email, 120)
 })
 
 const avatarUrl = computed(() => {
-  if (isUsingGravatar.value) {
-    return gravatarUrl.value
+  if (props.modelValue.avatar) {
+    if (props.modelValue.avatar.startsWith('http')) {
+      return props.modelValue.avatar
+    }
+    return avatarBlobUrl.value || gravatarUrl.value
   }
-  return props.modelValue.avatar || gravatarUrl.value
+  return gravatarUrl.value
 })
 
-const lastLoginFormatted = computed(() => {
-  if (props.modelValue.lastLogin) {
-    return new Date(props.modelValue.lastLogin).toLocaleString()
+const isUploadedAvatar = computed(() => {
+  return !!props.modelValue.avatar && !props.modelValue.avatar.startsWith('http')
+})
+
+const avatarSource = computed(() => {
+  if (!props.modelValue.avatar) return null
+  if (props.modelValue.avatar.startsWith('http')) {
+    return { icon: 'mdi-web', tooltip: 'Using Gravatar' }
   }
-  return 'Never'
+  return { icon: 'mdi-upload', tooltip: 'Uploaded avatar' }
 })
 
-const statusOptions = computed(() => {
-  return Object.values(ProfileStatus).map((status) => ({
-    title: status.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase()),
-    value: status,
-  }))
-})
-
-// Validation rules
 const rules = {
   required: (value: string) => !!value || 'This field is required',
   email: (value: string) => {
@@ -261,7 +278,6 @@ const rules = {
   },
 }
 
-// Methods
 const updateField = (field: keyof IProfile, value: string | boolean | undefined | null) => {
   const updatedProfile = {
     ...props.modelValue,
@@ -271,50 +287,65 @@ const updateField = (field: keyof IProfile, value: string | boolean | undefined 
   emit('change')
 }
 
-const useGravatar = () => {
-  updateField('avatar', gravatarUrl.value)
+const triggerFileInput = () => {
+  fileInput.value?.click()
 }
 
-const handleAvatarUpload = async (files: File | File[]) => {
-  const fileArray = Array.isArray(files) ? files : [files]
-
-  if (!fileArray || fileArray.length === 0) return
-
-  const file = fileArray[0]
+const handleFileSelected = async (event: Event) => {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
   if (!file) return
 
   if (!file.type.startsWith('image/')) {
-    alert('Please select an image file')
+    toast.error('Please select an image file')
+    input.value = ''
     return
   }
 
   const maxSize = 5 * 1024 * 1024
   if (file.size > maxSize) {
-    alert('File size must be less than 5MB')
+    toast.error('File size must be less than 5MB')
+    input.value = ''
     return
   }
 
   uploadingAvatar.value = true
-
   try {
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    const timestamp = new Date().getTime()
-    const fileName = `avatar_${props.modelValue.id}_${timestamp}.${file.name.split('.').pop()}`
-    const avatarPath = `/uploads/avatars/${fileName}`
-    updateField('avatar', avatarPath)
-
-    console.log('Avatar upload simulated:', {
-      originalFile: file.name,
-      size: file.size,
-      type: file.type,
-      simulatedPath: avatarPath,
-    })
+    const profileId = props.modelValue.id
+    if (!profileId) {
+      toast.error('Profile ID not available')
+      return
+    }
+    const response = await avatarService.uploadAvatar(profileId, file)
+    updateField('avatar', response.avatarPath)
+    toast.success('Avatar uploaded successfully')
   } catch (error) {
     console.error('Failed to upload avatar:', error)
-    alert('Failed to upload avatar. Please try again.')
+    toast.error('Failed to upload avatar. Please try again.')
   } finally {
     uploadingAvatar.value = false
-    avatarFile.value = []
+    input.value = ''
+  }
+}
+
+const handleRemoveAvatar = async () => {
+  if (!props.modelValue.avatar) return
+
+  uploadingAvatar.value = true
+  try {
+    const profileId = props.modelValue.id
+    if (!profileId) {
+      toast.error('Profile ID not available')
+      return
+    }
+    await avatarService.deleteAvatar()
+    updateField('avatar', null)
+    toast.success('Avatar removed successfully')
+  } catch (error) {
+    console.error('Failed to remove avatar:', error)
+    toast.error('Failed to remove avatar. Please try again.')
+  } finally {
+    uploadingAvatar.value = false
   }
 }
 </script>

--- a/src/main/webapp/src/components/profile/ProfileInfoCard.vue
+++ b/src/main/webapp/src/components/profile/ProfileInfoCard.vue
@@ -16,26 +16,6 @@
         <v-icon icon="mdi-account-off" size="48" class="mb-2" />
         <p>Unable to load profile information.</p>
       </div>
-
-      <v-alert
-        type="info"
-        variant="tonal"
-        class="mt-4"
-        icon="mdi-file-account"
-        title="Resume & Structured Data"
-        text="Manage your resume upload, structured work experience, education, and skills in the dedicated Resume section."
-      >
-        <template #append>
-          <v-btn
-            variant="text"
-            color="primary"
-            size="small"
-            :to="{ name: 'profile-resume' }"
-          >
-            Go to Resume
-          </v-btn>
-        </template>
-      </v-alert>
     </template>
 
     <template #actions>

--- a/src/main/webapp/src/components/profile/resume/ResumeTab.vue
+++ b/src/main/webapp/src/components/profile/resume/ResumeTab.vue
@@ -1,7 +1,5 @@
 <template>
   <div v-if="profile">
-    <ContactSectionCard :profile="profile" @update="onContactUpdate" />
-    <SummaryCard :profile="profile" @update="onContactUpdate" />
     <ResumeFileCard
       :profile-id="profile.id"
       :resume-id="profile.resumeId"
@@ -84,8 +82,6 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import type { IProfile } from '../../../models'
 import { useResumeDataStore } from '../../../stores/resume-data.store'
-import ContactSectionCard from './ContactSectionCard.vue'
-import SummaryCard from './SummaryCard.vue'
 import ResumeFileCard from './ResumeFileCard.vue'
 import SkillsCard from './SkillsCard.vue'
 import WorkExperienceCard from './WorkExperienceCard.vue'
@@ -156,11 +152,6 @@ async function onSaveAllExtracted(result: IResumeExtractionResult) {
 
 function onResumeIdUpdate(value: string | undefined) {
   emit('update:profile', { ...props.profile, resumeId: value })
-  emit('change')
-}
-
-function onContactUpdate(field: string, value: string | undefined | boolean) {
-  emit('update:profile', { ...props.profile, [field]: value })
   emit('change')
 }
 

--- a/src/main/webapp/src/services/avatar.service.ts
+++ b/src/main/webapp/src/services/avatar.service.ts
@@ -33,10 +33,10 @@ export default class AvatarService {
      * @param profileId - The profile ID
      * @returns Promise<void>
      */
-    deleteAvatar(profileId: string): Promise<void> {
+    deleteAvatar(): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             apiClient
-                .delete(`/api/profiles/${profileId}/avatar`)
+                .delete('/api/profiles/avatar')
                 .then(() => { resolve() })
                 .catch((err: unknown) => {
                     reject(err instanceof Error ? err : new Error(String(err)))
@@ -46,14 +46,15 @@ export default class AvatarService {
 
     /**
      * Get avatar URL for a profile
-     * @param avatarPath - The avatar file path from the profile
+     * @param avatarPath - The avatar filename or Gravatar URL
+     * @param profileId - The profile ID (required for internal avatars)
      * @returns Full URL to the avatar image
      */
-    getAvatarUrl(avatarPath: string): string {
+    getAvatarUrl(avatarPath: string, profileId?: string): string {
         if (avatarPath.startsWith('http')) {
             return avatarPath // External URL (like Gravatar)
         }
-        return `/api/files${avatarPath}` // Internal file storage
+        return `/api/public/avatars/${profileId}` // Public avatar endpoint
     }
 
     /**

--- a/src/main/webapp/src/views/admin/UserDetailView.vue
+++ b/src/main/webapp/src/views/admin/UserDetailView.vue
@@ -30,6 +30,7 @@
             <UserAvatar
               :email="detail.profile.email"
               :avatar-url="detail.profile.avatar"
+              :profile-id="detail.profile.id"
               :size="72"
             />
           </v-col>

--- a/src/main/webapp/src/views/admin/UsersView.vue
+++ b/src/main/webapp/src/views/admin/UsersView.vue
@@ -48,7 +48,7 @@
         <!-- Name -->
         <template #item.name="{ item }">
           <div class="d-flex align-center gap-2 py-1">
-            <UserAvatar :email="item.email" :avatar-url="item.avatar" :size="32" />
+            <UserAvatar :email="item.email" :avatar-url="item.avatar" :profile-id="item.id" :size="32" />
             <div class="ml-3">
               <div class="text-body-2 font-weight-medium">{{ fullName(item) }}</div>
               <div class="text-caption text-medium-emphasis">{{ item.email }}</div>


### PR DESCRIPTION
## Summary

Redesign the Profile Information page with a unified layout, backend avatar support, and cleanup of resume tab.

### Phase 1 — Backend: Avatar endpoints
- Added `uploadAvatar`, `deleteAvatar`, `getAvatar` to `FileService` / `LocalFileService`
- Added `POST /api/profiles/avatar`, `DELETE /api/profiles/avatar`, `GET /api/profiles/avatar` endpoints to `ProfileResource`
- Added `updateAvatar` query to `ProfileRepository`

### Phase 2 — Frontend: Merged profile form
- Redesigned `ProfileForm.vue` with clickable avatar, file upload, source badge (Gravatar vs uploaded)
- Moved Phone, LinkedIn, Portfolio, Professional Summary from resume tab into profile form
- Removed low-value fields: status, subscription, lastLogin, emailVerification toggle
- Email is now read-only with verified/unverified icon
- Removed "Resume & Structured Data" alert from `ProfileInfoCard`

### Phase 3 — Frontend: ResumeTab cleanup
- Removed `ContactSectionCard` and `SummaryCard` components and their imports from `ResumeTab.vue`
- Removed `onContactUpdate` handler (no longer needed — fields live in ProfileForm now)
