### PR TITLE
feat: redesign skills section - popover add skill, tags with delete

### DIFF
--- a/src/main/webapp/src/components/FormDialog.vue
+++ b/src/main/webapp/src/components/FormDialog.vue
@@ -36,6 +36,7 @@
           @click="onCancel"
         />
         <v-btn
+          v-if="!hideConfirm"
           :text="confirmText"
           color="primary"
           variant="flat"
@@ -63,6 +64,7 @@ export interface FormDialogProps {
   loading?: boolean
   valid?: boolean | null
   maxWidth?: string | number
+  hideConfirm?: boolean
 }
 
 const props = withDefaults(defineProps<FormDialogProps>(), {
@@ -72,6 +74,7 @@ const props = withDefaults(defineProps<FormDialogProps>(), {
   valid: true,
   maxWidth: 600,
   icon: undefined,
+  hideConfirm: false,
 })
 
 const emit = defineEmits<{

--- a/src/main/webapp/src/components/profile/resume/AffiliationCard.vue
+++ b/src/main/webapp/src/components/profile/resume/AffiliationCard.vue
@@ -1,14 +1,14 @@
 <template>
-  <v-card elevation="0" border rounded="lg" class="mb-4">
-    <div class="d-flex align-center pa-4 pb-0">
+  <FormCard collapsible default-open class="mb-4">
+    <template #title>
       <v-icon icon="mdi-account-group" color="primary" size="28" class="mr-3" />
-      <div class="flex-grow-1">
-        <div class="text-body-1 font-weight-medium">Professional Affiliations</div>
-      </div>
-      <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-    </div>
+      Professional Affiliations
+    </template>
 
-    <v-card-text>
+    <template #default>
+      <div class="d-flex justify-end mb-2">
+        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
+      </div>
       <div v-if="store.affiliations.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-account-group-outline" size="40" class="mb-2" />
         <p class="text-body-2">No professional affiliations added yet.</p>
@@ -41,56 +41,56 @@
           {{ aff.description.substring(0, 120) }}{{ aff.description.length > 120 ? '...' : '' }}
         </div>
       </div>
-    </v-card-text>
+      <FormDialog
+        v-model="showDialog"
+        :title="editingId ? 'Edit Affiliation' : 'Add Affiliation'"
+        icon="mdi-account-group"
+        :loading="saving"
+        :valid="formValid"
+        @confirm="saveAffiliation"
+        @cancel="showDialog = false"
+      >
+        <v-row>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.organization" label="Organization" variant="outlined" density="compact" :rules="[rules.required]" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.role" label="Role" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-switch v-model="form.isCurrent" label="Currently active" color="primary" hide-details />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.startYear" label="Start Year" type="number" variant="outlined" density="compact" min="1900" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.endYear" label="End Year" type="number" variant="outlined" density="compact" min="1900" :disabled="form.isCurrent" />
+          </v-col>
+          <v-col cols="12">
+            <v-textarea v-model="form.description" label="Description" variant="outlined" density="compact" rows="2" />
+          </v-col>
+        </v-row>
+      </FormDialog>
 
-    <FormDialog
-      v-model="showDialog"
-      :title="editingId ? 'Edit Affiliation' : 'Add Affiliation'"
-      icon="mdi-account-group"
-      :loading="saving"
-      :valid="formValid"
-      @confirm="saveAffiliation"
-      @cancel="showDialog = false"
-    >
-      <v-row>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.organization" label="Organization" variant="outlined" density="compact" :rules="[rules.required]" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.role" label="Role" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-switch v-model="form.isCurrent" label="Currently active" color="primary" hide-details />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.startYear" label="Start Year" type="number" variant="outlined" density="compact" min="1900" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.endYear" label="End Year" type="number" variant="outlined" density="compact" min="1900" :disabled="form.isCurrent" />
-        </v-col>
-        <v-col cols="12">
-          <v-textarea v-model="form.description" label="Description" variant="outlined" density="compact" rows="2" />
-        </v-col>
-      </v-row>
-    </FormDialog>
-
-    <ConfirmDialog
-      v-model="deleteConfirm"
-      title="Delete Affiliation"
-      variant="error"
-      confirm-text="Delete"
-      :loading="deleting"
-      @confirm="doDelete"
-    >
-      Are you sure you want to delete "{{ deleteTarget?.organization }}"?
-    </ConfirmDialog>
-  </v-card>
+      <ConfirmDialog
+        v-model="deleteConfirm"
+        title="Delete Affiliation"
+        variant="error"
+        confirm-text="Delete"
+        :loading="deleting"
+        @confirm="doDelete"
+      >
+        Are you sure you want to delete "{{ deleteTarget?.organization }}"?
+      </ConfirmDialog>
+    </template>
+  </FormCard>
 </template>
 
 <script setup lang="ts">
 import { ref, reactive, computed } from 'vue'
 import type { IProfessionalAffiliation } from '../../../models/resume-data.model'
 import { useResumeDataStore } from '../../../stores/resume-data.store'
+import FormCard from '../../forms/FormCard.vue'
 import FormDialog from '../../FormDialog.vue'
 import ConfirmDialog from '../../ConfirmDialog.vue'
 

--- a/src/main/webapp/src/components/profile/resume/AwardCard.vue
+++ b/src/main/webapp/src/components/profile/resume/AwardCard.vue
@@ -1,14 +1,14 @@
 <template>
-  <v-card elevation="0" border rounded="lg" class="mb-4">
-    <div class="d-flex align-center pa-4 pb-0">
+  <FormCard collapsible default-open class="mb-4">
+    <template #title>
       <v-icon icon="mdi-trophy" color="primary" size="28" class="mr-3" />
-      <div class="flex-grow-1">
-        <div class="text-body-1 font-weight-medium">Awards</div>
-      </div>
-      <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-    </div>
+      Awards
+    </template>
 
-    <v-card-text>
+    <template #default>
+      <div class="d-flex justify-end mb-2">
+        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
+      </div>
       <div v-if="store.awards.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-trophy-outline" size="40" class="mb-2" />
         <p class="text-body-2">No awards added yet.</p>
@@ -39,50 +39,50 @@
           {{ award.description.substring(0, 120) }}{{ award.description.length > 120 ? '...' : '' }}
         </div>
       </div>
-    </v-card-text>
+      <FormDialog
+        v-model="showDialog"
+        :title="editingId ? 'Edit Award' : 'Add Award'"
+        icon="mdi-trophy"
+        :loading="saving"
+        :valid="formValid"
+        @confirm="saveAward"
+        @cancel="showDialog = false"
+      >
+        <v-row>
+          <v-col cols="12">
+            <v-text-field v-model="form.title" label="Award Title" variant="outlined" density="compact" :rules="[rules.required]" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.issuer" label="Issuer" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.awardDate" label="Award Date" type="date" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="12">
+            <v-textarea v-model="form.description" label="Description" variant="outlined" density="compact" rows="2" />
+          </v-col>
+        </v-row>
+      </FormDialog>
 
-    <FormDialog
-      v-model="showDialog"
-      :title="editingId ? 'Edit Award' : 'Add Award'"
-      icon="mdi-trophy"
-      :loading="saving"
-      :valid="formValid"
-      @confirm="saveAward"
-      @cancel="showDialog = false"
-    >
-      <v-row>
-        <v-col cols="12">
-          <v-text-field v-model="form.title" label="Award Title" variant="outlined" density="compact" :rules="[rules.required]" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.issuer" label="Issuer" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.awardDate" label="Award Date" type="date" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="12">
-          <v-textarea v-model="form.description" label="Description" variant="outlined" density="compact" rows="2" />
-        </v-col>
-      </v-row>
-    </FormDialog>
-
-    <ConfirmDialog
-      v-model="deleteConfirm"
-      title="Delete Award"
-      variant="error"
-      confirm-text="Delete"
-      :loading="deleting"
-      @confirm="doDelete"
-    >
-      Are you sure you want to delete "{{ deleteTarget?.title }}"?
-    </ConfirmDialog>
-  </v-card>
+      <ConfirmDialog
+        v-model="deleteConfirm"
+        title="Delete Award"
+        variant="error"
+        confirm-text="Delete"
+        :loading="deleting"
+        @confirm="doDelete"
+      >
+        Are you sure you want to delete "{{ deleteTarget?.title }}"?
+      </ConfirmDialog>
+    </template>
+  </FormCard>
 </template>
 
 <script setup lang="ts">
 import { ref, reactive, computed } from 'vue'
 import type { IResumeAward } from '../../../models/resume-data.model'
 import { useResumeDataStore } from '../../../stores/resume-data.store'
+import FormCard from '../../forms/FormCard.vue'
 import FormDialog from '../../FormDialog.vue'
 import ConfirmDialog from '../../ConfirmDialog.vue'
 

--- a/src/main/webapp/src/components/profile/resume/BulletEditor.vue
+++ b/src/main/webapp/src/components/profile/resume/BulletEditor.vue
@@ -8,11 +8,13 @@
       <template #prepend>
         <span class="bullet-number text-caption text-medium-emphasis mr-1">{{ index + 1 }}.</span>
       </template>
-      <v-text-field
+      <v-textarea
         :model-value="bullet.content"
         variant="outlined"
         density="compact"
         hide-details
+        auto-grow
+        rows="2"
         placeholder="Describe an accomplishment or responsibility..."
         class="bullet-input"
         @update:model-value="updateBullet(index, $event as string)"
@@ -38,11 +40,29 @@
     >
       Add bullet point
     </v-btn>
+    <div v-if="dirty" class="d-flex ga-2 mt-2">
+      <v-btn
+        color="success"
+        prepend-icon="mdi-content-save"
+        size="small"
+        @click="emitBullets"
+      >
+        Save
+      </v-btn>
+      <v-btn
+        color="warning"
+        prepend-icon="mdi-undo"
+        size="small"
+        @click="revertBullets"
+      >
+        Revert
+      </v-btn>
+    </div>
   </v-list>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, computed, watch } from 'vue'
 import type { IWorkExperienceBullet } from '../../../models/resume-data.model'
 
 const props = defineProps<{
@@ -57,6 +77,15 @@ const localBullets = ref<IWorkExperienceBullet[]>(props.bullets.length
   ? [...props.bullets]
   : [{ content: '', displayOrder: 0 }]
 )
+
+const dirty = computed(() => {
+  const current = localBullets.value
+  const original = props.bullets
+  const effectiveCurrent = current.filter(b => b.content)
+  const effectiveOriginal = original.filter(b => b.content)
+  if (effectiveCurrent.length !== effectiveOriginal.length) return true
+  return effectiveCurrent.some((b, i) => b.content !== effectiveOriginal[i]?.content)
+})
 
 watch(
   () => props.bullets,
@@ -77,9 +106,16 @@ function emitBullets() {
   })))
 }
 
+function revertBullets() {
+  if (props.bullets.length === 0) {
+    localBullets.value = [{ content: '', displayOrder: 0 }]
+  } else {
+    localBullets.value = props.bullets.map((b, i) => ({ ...b, displayOrder: i }))
+  }
+}
+
 function addBullet() {
   localBullets.value.push({ content: '', displayOrder: localBullets.value.length })
-  emitBullets()
 }
 
 function removeBullet(index: number) {
@@ -87,13 +123,11 @@ function removeBullet(index: number) {
   if (localBullets.value.length === 0) {
     localBullets.value.push({ content: '', displayOrder: 0 })
   }
-  emitBullets()
 }
 
 function updateBullet(index: number, content: string) {
   if (localBullets.value[index]) {
     localBullets.value[index].content = content
-    emitBullets()
   }
 }
 </script>

--- a/src/main/webapp/src/components/profile/resume/CertificationCard.vue
+++ b/src/main/webapp/src/components/profile/resume/CertificationCard.vue
@@ -1,14 +1,14 @@
 <template>
-  <v-card elevation="0" border rounded="lg" class="mb-4">
-    <div class="d-flex align-center pa-4 pb-0">
+  <FormCard collapsible default-open class="mb-4">
+    <template #title>
       <v-icon icon="mdi-certificate" color="primary" size="28" class="mr-3" />
-      <div class="flex-grow-1">
-        <div class="text-body-1 font-weight-medium">Certifications</div>
-      </div>
-      <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-    </div>
+      Certifications
+    </template>
 
-    <v-card-text>
+    <template #default>
+      <div class="d-flex justify-end mb-2">
+        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
+      </div>
       <div v-if="store.certifications.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-certificate-outline" size="40" class="mb-2" />
         <p class="text-body-2">No certifications added yet.</p>
@@ -33,56 +33,56 @@
           </template>
         </v-tooltip>
       </div>
-    </v-card-text>
+      <FormDialog
+        v-model="showDialog"
+        :title="editingId ? 'Edit Certification' : 'Add Certification'"
+        icon="mdi-certificate"
+        :loading="saving"
+        :valid="formValid"
+        @confirm="saveCertification"
+        @cancel="showDialog = false"
+      >
+        <v-row>
+          <v-col cols="12">
+            <v-text-field v-model="form.name" label="Certification Name" variant="outlined" density="compact" :rules="[rules.required]" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.issuingOrganization" label="Issuing Organization" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.issueDate" label="Issue Date" type="date" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.expirationDate" label="Expiration Date" type="date" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.credentialId" label="Credential ID" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.credentialUrl" label="Credential URL" variant="outlined" density="compact" />
+          </v-col>
+        </v-row>
+      </FormDialog>
 
-    <FormDialog
-      v-model="showDialog"
-      :title="editingId ? 'Edit Certification' : 'Add Certification'"
-      icon="mdi-certificate"
-      :loading="saving"
-      :valid="formValid"
-      @confirm="saveCertification"
-      @cancel="showDialog = false"
-    >
-      <v-row>
-        <v-col cols="12">
-          <v-text-field v-model="form.name" label="Certification Name" variant="outlined" density="compact" :rules="[rules.required]" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.issuingOrganization" label="Issuing Organization" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.issueDate" label="Issue Date" type="date" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.expirationDate" label="Expiration Date" type="date" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.credentialId" label="Credential ID" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.credentialUrl" label="Credential URL" variant="outlined" density="compact" />
-        </v-col>
-      </v-row>
-    </FormDialog>
-
-    <ConfirmDialog
-      v-model="deleteConfirm"
-      title="Delete Certification"
-      variant="error"
-      confirm-text="Delete"
-      :loading="deleting"
-      @confirm="doDelete"
-    >
-      Are you sure you want to delete "{{ deleteTarget?.name }}"?
-    </ConfirmDialog>
-  </v-card>
+      <ConfirmDialog
+        v-model="deleteConfirm"
+        title="Delete Certification"
+        variant="error"
+        confirm-text="Delete"
+        :loading="deleting"
+        @confirm="doDelete"
+      >
+        Are you sure you want to delete "{{ deleteTarget?.name }}"?
+      </ConfirmDialog>
+    </template>
+  </FormCard>
 </template>
 
 <script setup lang="ts">
 import { ref, reactive, computed } from 'vue'
 import type { IResumeCertification } from '../../../models/resume-data.model'
 import { useResumeDataStore } from '../../../stores/resume-data.store'
+import FormCard from '../../forms/FormCard.vue'
 import FormDialog from '../../FormDialog.vue'
 import ConfirmDialog from '../../ConfirmDialog.vue'
 

--- a/src/main/webapp/src/components/profile/resume/EducationCard.vue
+++ b/src/main/webapp/src/components/profile/resume/EducationCard.vue
@@ -52,10 +52,29 @@
         icon="mdi-school"
         :loading="saving"
         :valid="formValid"
+        hide-confirm
         @confirm="saveEducation"
-        @cancel="showDialog = false"
+        @cancel="revertForm"
       >
         <v-row>
+          <v-col cols="12" class="d-flex ga-2 pb-0">
+            <v-btn
+              v-if="dirty"
+              color="success"
+              prepend-icon="mdi-content-save"
+              @click="saveEducation"
+            >
+              Save
+            </v-btn>
+            <v-btn
+              color="secondary"
+              variant="outlined"
+              prepend-icon="mdi-undo"
+              @click="revertForm"
+            >
+              Cancel
+            </v-btn>
+          </v-col>
           <v-col cols="12" md="6">
             <v-text-field v-model="form.school" label="School" variant="outlined" density="compact" :rules="[rules.required]" />
           </v-col>
@@ -149,11 +168,36 @@ const form = reactive({
   courses: [] as string[],
 })
 
+const formSnapshot = reactive({
+  school: '',
+  degree: '',
+  fieldOfStudy: '',
+  startYear: undefined as number | undefined,
+  endYear: undefined as number | undefined,
+  isCurrent: false,
+  gpa: '',
+  honors: '',
+  courses: [] as string[],
+})
+
 const rules = {
   required: (v: string) => !!v || 'This field is required',
 }
 
 const formValid = computed(() => !!form.school && !!form.degree && !!form.fieldOfStudy)
+
+const dirty = computed(() => {
+  if (!editingId.value) return true
+  return form.school !== formSnapshot.school
+    || form.degree !== formSnapshot.degree
+    || form.fieldOfStudy !== formSnapshot.fieldOfStudy
+    || form.startYear !== formSnapshot.startYear
+    || form.endYear !== formSnapshot.endYear
+    || form.isCurrent !== formSnapshot.isCurrent
+    || form.gpa !== formSnapshot.gpa
+    || form.honors !== formSnapshot.honors
+    || JSON.stringify(form.courses) !== JSON.stringify(formSnapshot.courses)
+})
 
 function formatDate(startYear?: number | null, endYear?: number | null, isCurrent?: boolean | null): string {
   const end = isCurrent ? 'Present' : endYear || ''
@@ -173,9 +217,22 @@ function resetForm() {
   form.courses = []
 }
 
+function takeSnapshot() {
+  formSnapshot.school = form.school
+  formSnapshot.degree = form.degree
+  formSnapshot.fieldOfStudy = form.fieldOfStudy
+  formSnapshot.startYear = form.startYear
+  formSnapshot.endYear = form.endYear
+  formSnapshot.isCurrent = form.isCurrent
+  formSnapshot.gpa = form.gpa
+  formSnapshot.honors = form.honors
+  formSnapshot.courses = [...form.courses]
+}
+
 function openAdd() {
   editingId.value = null
   resetForm()
+  takeSnapshot()
   showDialog.value = true
 }
 
@@ -190,7 +247,23 @@ function editEducation(edu: IEducation) {
   form.gpa = edu.gpa || ''
   form.honors = edu.honors || ''
   form.courses = edu.courses ? [...edu.courses] : []
+  takeSnapshot()
   showDialog.value = true
+}
+
+function revertForm() {
+  form.school = formSnapshot.school
+  form.degree = formSnapshot.degree
+  form.fieldOfStudy = formSnapshot.fieldOfStudy
+  form.startYear = formSnapshot.startYear
+  form.endYear = formSnapshot.endYear
+  form.isCurrent = formSnapshot.isCurrent
+  form.gpa = formSnapshot.gpa
+  form.honors = formSnapshot.honors
+  form.courses = [...formSnapshot.courses]
+  if (!editingId.value) {
+    showDialog.value = false
+  }
 }
 
 async function saveEducation() {
@@ -202,6 +275,7 @@ async function saveEducation() {
     } else {
       await store.createEducation(dto)
     }
+    takeSnapshot()
     showDialog.value = false
   } finally {
     saving.value = false

--- a/src/main/webapp/src/components/profile/resume/EducationCard.vue
+++ b/src/main/webapp/src/components/profile/resume/EducationCard.vue
@@ -1,145 +1,141 @@
 <template>
-  <v-card
-    v-if="educationItem"
-    elevation="0"
-    border
-    rounded="lg"
-    class="mb-4"
-  >
-    <div class="d-flex align-center pa-4 pb-0">
+  <FormCard collapsible default-open class="mb-4">
+    <template #title>
       <v-icon icon="mdi-school" color="primary" size="28" class="mr-3" />
-      <div class="flex-grow-1">
-        <div class="text-body-1 font-weight-medium">
-          {{ educationItem.degree || 'Untitled' }}
+      Education
+    </template>
+
+    <template #default>
+      <div class="d-flex justify-end mb-2">
+        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
+      </div>
+
+      <div v-if="store.education.length === 0" class="text-center py-4 text-medium-emphasis">
+        <v-icon icon="mdi-school-outline" size="40" class="mb-2" />
+        <p class="text-body-2">No education added yet.</p>
+      </div>
+
+      <div v-for="edu in store.education" :key="edu.id" class="mb-3 pa-2 rounded">
+        <div class="d-flex align-center mb-1">
+          <v-icon icon="mdi-school-outline" size="small" color="primary" class="mr-2" />
+          <div class="flex-grow-1">
+            <span class="text-subtitle-2 font-weight-medium">{{ edu.degree }}</span>
+            <span v-if="edu.school" class="text-caption text-medium-emphasis ml-2">
+              &mdash; {{ edu.school }}
+            </span>
+          </div>
+          <v-tooltip text="Edit" location="top">
+            <template #activator="{ props: tp }">
+              <v-btn v-bind="tp" icon="mdi-pencil" variant="text" size="x-small" color="primary" class="mr-1" @click="editEducation(edu)" />
+            </template>
+          </v-tooltip>
+          <v-tooltip text="Delete" location="top">
+            <template #activator="{ props: tp }">
+              <v-btn v-bind="tp" icon="mdi-delete" variant="text" size="x-small" color="error" @click="deleteTarget = edu" />
+            </template>
+          </v-tooltip>
         </div>
-        <div class="text-caption text-medium-emphasis">
-          {{ educationItem.school }}
-          <template v-if="educationItem.fieldOfStudy"> &middot; {{ educationItem.fieldOfStudy }} </template>
+        <div v-if="edu.fieldOfStudy" class="text-caption text-medium-emphasis ml-8">
+          {{ edu.fieldOfStudy }}
+        </div>
+        <div v-if="edu.startYear || edu.endYear" class="text-caption text-medium-emphasis ml-8">
+          {{ formatDate(edu.startYear, edu.endYear, edu.isCurrent) }}
+        </div>
+        <div v-if="edu.gpa" class="text-caption text-medium-emphasis ml-8">
+          GPA: {{ edu.gpa }}
         </div>
       </div>
-      <div class="d-flex ga-1">
-        <v-tooltip text="Edit" location="top">
-          <template #activator="{ props: tp }">
-            <v-btn v-bind="tp" icon="mdi-pencil" variant="text" size="small" color="primary" @click="editDialog = true" />
-          </template>
-        </v-tooltip>
-        <v-tooltip text="Delete" location="top">
-          <template #activator="{ props: tp }">
-            <v-btn v-bind="tp" icon="mdi-delete" variant="text" size="small" color="error" @click="confirmDelete = true" />
-          </template>
-        </v-tooltip>
-      </div>
-    </div>
 
-    <v-card-text class="pt-2">
-      <div v-if="educationItem.startYear || educationItem.endYear" class="text-caption text-medium-emphasis mb-1">
-        {{ dateRange }}
-      </div>
-      <div v-if="educationItem.gpa" class="text-caption text-medium-emphasis">
-        GPA: {{ educationItem.gpa }}
-      </div>
-      <div v-if="educationItem.honors" class="text-caption text-medium-emphasis">
-        {{ educationItem.honors }}
-      </div>
-      <v-list v-if="educationItem.courses && educationItem.courses.length" density="compact" class="bg-transparent pa-0 mt-1">
-        <v-list-item v-for="(course, i) in educationItem.courses" :key="i" class="pa-0 text-caption">
-          <template #prepend>
-            <v-icon icon="mdi-book-open-variant" size="x-small" class="mr-1" />
-          </template>
-          {{ course }}
-        </v-list-item>
-      </v-list>
-    </v-card-text>
+      <FormDialog
+        v-model="showDialog"
+        :title="editingId ? 'Edit Education' : 'Add Education'"
+        icon="mdi-school"
+        :loading="saving"
+        :valid="formValid"
+        @confirm="saveEducation"
+        @cancel="showDialog = false"
+      >
+        <v-row>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.school" label="School" variant="outlined" density="compact" :rules="[rules.required]" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.degree" label="Degree" variant="outlined" density="compact" :rules="[rules.required]" />
+          </v-col>
+          <v-col cols="12">
+            <v-text-field v-model="form.fieldOfStudy" label="Field of Study" variant="outlined" density="compact" :rules="[rules.required]" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.startYear" label="Start Year" type="number" variant="outlined" density="compact" min="1900" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field
+              v-model="form.endYear"
+              label="End Year"
+              type="number"
+              variant="outlined"
+              density="compact"
+              min="1900"
+              :disabled="form.isCurrent"
+            />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-switch v-model="form.isCurrent" label="Currently enrolled" color="primary" hide-details />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.gpa" label="GPA" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.honors" label="Honors" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="12">
+            <v-combobox
+              v-model="form.courses"
+              label="Relevant Courses"
+              variant="outlined"
+              density="compact"
+              multiple
+              chips
+              deletable-chips
+              small-chips
+              append-icon="mdi-plus"
+              hint="Type a course name and press Enter"
+              persistent-hint
+            />
+          </v-col>
+        </v-row>
+      </FormDialog>
 
-    <FormDialog
-      v-model="editDialog"
-      title="Edit Education"
-      icon="mdi-school"
-      :loading="saving"
-      :valid="formValid"
-      @confirm="saveEdit"
-      @cancel="editDialog = false"
-    >
-      <v-row>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.school" label="School" variant="outlined" density="compact" :rules="[rules.required]" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.degree" label="Degree" variant="outlined" density="compact" :rules="[rules.required]" />
-        </v-col>
-        <v-col cols="12">
-          <v-text-field v-model="form.fieldOfStudy" label="Field of Study" variant="outlined" density="compact" :rules="[rules.required]" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.startYear" label="Start Year" type="number" variant="outlined" density="compact" min="1900" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field
-            v-model="form.endYear"
-            label="End Year"
-            type="number"
-            variant="outlined"
-            density="compact"
-            min="1900"
-            :disabled="form.isCurrent"
-          />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-switch v-model="form.isCurrent" label="Currently enrolled" color="primary" hide-details />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.gpa" label="GPA" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.honors" label="Honors" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="12">
-          <v-combobox
-            v-model="form.courses"
-            label="Relevant Courses"
-            variant="outlined"
-            density="compact"
-            multiple
-            chips
-            deletable-chips
-            small-chips
-            append-icon="mdi-plus"
-            hint="Type a course name and press Enter"
-            persistent-hint
-          />
-        </v-col>
-      </v-row>
-    </FormDialog>
-
-    <ConfirmDialog
-      v-model="confirmDelete"
-      title="Delete Education"
-      variant="error"
-      confirm-text="Delete"
-      :loading="deleting"
-      @confirm="doDelete"
-    >
-      Are you sure you want to delete this education entry? This action cannot be undone.
-    </ConfirmDialog>
-  </v-card>
+      <ConfirmDialog
+        v-model="deleteConfirm"
+        title="Delete Education"
+        variant="error"
+        confirm-text="Delete"
+        :loading="deleting"
+        @confirm="doDelete"
+      >
+        Are you sure you want to delete "{{ deleteTarget?.degree }}" at {{ deleteTarget?.school }}?
+      </ConfirmDialog>
+    </template>
+  </FormCard>
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, watch } from 'vue'
+import { ref, reactive, computed } from 'vue'
 import type { IEducation } from '../../../models/resume-data.model'
 import { useResumeDataStore } from '../../../stores/resume-data.store'
+import FormCard from '../../forms/FormCard.vue'
 import FormDialog from '../../FormDialog.vue'
 import ConfirmDialog from '../../ConfirmDialog.vue'
 
-const props = defineProps<{
-  educationItem: IEducation
-}>()
-
 const store = useResumeDataStore()
-const editDialog = ref(false)
-const confirmDelete = ref(false)
+
+const showDialog = ref(false)
 const saving = ref(false)
+const editingId = ref<string | null>(null)
+const deleteConfirm = ref(false)
 const deleting = ref(false)
+const deleteTarget = ref<IEducation | null>(null)
 
 const form = reactive({
   school: '',
@@ -159,45 +155,66 @@ const rules = {
 
 const formValid = computed(() => !!form.school && !!form.degree && !!form.fieldOfStudy)
 
-const dateRange = computed(() => {
-  const edu = props.educationItem
-  const end = edu.isCurrent ? 'Present' : edu.endYear || ''
-  if (!edu.startYear && !end) return ''
-  return `${edu.startYear || '?'} — ${end}`
-})
+function formatDate(startYear?: number | null, endYear?: number | null, isCurrent?: boolean | null): string {
+  const end = isCurrent ? 'Present' : endYear || ''
+  if (!startYear && !end) return ''
+  return `${startYear || '?'} — ${end}`
+}
 
-watch(editDialog, (open) => {
-  if (open) {
-    form.school = props.educationItem.school || ''
-    form.degree = props.educationItem.degree || ''
-    form.fieldOfStudy = props.educationItem.fieldOfStudy || ''
-    form.startYear = props.educationItem.startYear ?? undefined
-    form.endYear = props.educationItem.endYear ?? undefined
-    form.isCurrent = props.educationItem.isCurrent ?? false
-    form.gpa = props.educationItem.gpa || ''
-    form.honors = props.educationItem.honors || ''
-    form.courses = props.educationItem.courses ? [...props.educationItem.courses] : []
-  }
-})
+function resetForm() {
+  form.school = ''
+  form.degree = ''
+  form.fieldOfStudy = ''
+  form.startYear = undefined
+  form.endYear = undefined
+  form.isCurrent = false
+  form.gpa = ''
+  form.honors = ''
+  form.courses = []
+}
 
-async function saveEdit() {
-  if (!props.educationItem.id) return
+function openAdd() {
+  editingId.value = null
+  resetForm()
+  showDialog.value = true
+}
+
+function editEducation(edu: IEducation) {
+  editingId.value = edu.id || null
+  form.school = edu.school || ''
+  form.degree = edu.degree || ''
+  form.fieldOfStudy = edu.fieldOfStudy || ''
+  form.startYear = edu.startYear ?? undefined
+  form.endYear = edu.endYear ?? undefined
+  form.isCurrent = edu.isCurrent ?? false
+  form.gpa = edu.gpa || ''
+  form.honors = edu.honors || ''
+  form.courses = edu.courses ? [...edu.courses] : []
+  showDialog.value = true
+}
+
+async function saveEducation() {
   saving.value = true
   try {
     const dto: IEducation = { ...form }
-    await store.updateEducation(props.educationItem.id, dto)
-    editDialog.value = false
+    if (editingId.value) {
+      await store.updateEducation(editingId.value, dto)
+    } else {
+      await store.createEducation(dto)
+    }
+    showDialog.value = false
   } finally {
     saving.value = false
   }
 }
 
 async function doDelete() {
-  if (!props.educationItem.id) return
+  if (!deleteTarget.value?.id) return
   deleting.value = true
   try {
-    await store.deleteEducation(props.educationItem.id)
-    confirmDelete.value = false
+    await store.deleteEducation(deleteTarget.value.id)
+    deleteConfirm.value = false
+    deleteTarget.value = null
   } finally {
     deleting.value = false
   }

--- a/src/main/webapp/src/components/profile/resume/LanguageCard.vue
+++ b/src/main/webapp/src/components/profile/resume/LanguageCard.vue
@@ -1,14 +1,14 @@
 <template>
-  <v-card elevation="0" border rounded="lg" class="mb-4">
-    <div class="d-flex align-center pa-4 pb-0">
+  <FormCard collapsible default-open class="mb-4">
+    <template #title>
       <v-icon icon="mdi-translate" color="primary" size="28" class="mr-3" />
-      <div class="flex-grow-1">
-        <div class="text-body-1 font-weight-medium">Languages</div>
-      </div>
-      <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-    </div>
+      Languages
+    </template>
 
-    <v-card-text>
+    <template #default>
+      <div class="d-flex justify-end mb-2">
+        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
+      </div>
       <div v-if="store.languages.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-translate" size="40" class="mb-2" />
         <p class="text-body-2">No languages added yet.</p>
@@ -27,58 +27,58 @@
           {{ lang.language }} &middot; {{ formatProficiency(lang.proficiency) }}
         </v-chip>
       </div>
-    </v-card-text>
+      <FormDialog
+        v-model="showDialog"
+        :title="editingId ? 'Edit Language' : 'Add Language'"
+        icon="mdi-translate"
+        :loading="saving"
+        :valid="formValid"
+        @confirm="saveLanguage"
+        @cancel="showDialog = false"
+      >
+        <v-row>
+          <v-col cols="12" md="6">
+            <v-text-field
+              v-model="form.language"
+              label="Language"
+              variant="outlined"
+              density="compact"
+              :rules="[rules.required]"
+              placeholder="e.g., English, Spanish"
+            />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-select
+              v-model="form.proficiency"
+              label="Proficiency"
+              variant="outlined"
+              density="compact"
+              :items="proficiencyItems"
+              :rules="[rules.required]"
+            />
+          </v-col>
+        </v-row>
+      </FormDialog>
 
-    <FormDialog
-      v-model="showDialog"
-      :title="editingId ? 'Edit Language' : 'Add Language'"
-      icon="mdi-translate"
-      :loading="saving"
-      :valid="formValid"
-      @confirm="saveLanguage"
-      @cancel="showDialog = false"
-    >
-      <v-row>
-        <v-col cols="12" md="6">
-          <v-text-field
-            v-model="form.language"
-            label="Language"
-            variant="outlined"
-            density="compact"
-            :rules="[rules.required]"
-            placeholder="e.g., English, Spanish"
-          />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-select
-            v-model="form.proficiency"
-            label="Proficiency"
-            variant="outlined"
-            density="compact"
-            :items="proficiencyItems"
-            :rules="[rules.required]"
-          />
-        </v-col>
-      </v-row>
-    </FormDialog>
-
-    <ConfirmDialog
-      v-model="deleteConfirm"
-      title="Delete Language"
-      variant="error"
-      confirm-text="Delete"
-      :loading="deleting"
-      @confirm="doDelete"
-    >
-      Are you sure you want to delete "{{ deleteTarget?.language }}"?
-    </ConfirmDialog>
-  </v-card>
+      <ConfirmDialog
+        v-model="deleteConfirm"
+        title="Delete Language"
+        variant="error"
+        confirm-text="Delete"
+        :loading="deleting"
+        @confirm="doDelete"
+      >
+        Are you sure you want to delete "{{ deleteTarget?.language }}"?
+      </ConfirmDialog>
+    </template>
+  </FormCard>
 </template>
 
 <script setup lang="ts">
 import { ref, reactive, computed } from 'vue'
 import type { IResumeLanguage, LanguageProficiency } from '../../../models/resume-data.model'
 import { useResumeDataStore } from '../../../stores/resume-data.store'
+import FormCard from '../../forms/FormCard.vue'
 import FormDialog from '../../FormDialog.vue'
 import ConfirmDialog from '../../ConfirmDialog.vue'
 

--- a/src/main/webapp/src/components/profile/resume/ProjectCard.vue
+++ b/src/main/webapp/src/components/profile/resume/ProjectCard.vue
@@ -1,14 +1,14 @@
 <template>
-  <v-card elevation="0" border rounded="lg" class="mb-4">
-    <div class="d-flex align-center pa-4 pb-0">
+  <FormCard collapsible default-open class="mb-4">
+    <template #title>
       <v-icon icon="mdi-code-braces" color="primary" size="28" class="mr-3" />
-      <div class="flex-grow-1">
-        <div class="text-body-1 font-weight-medium">Projects</div>
-      </div>
-      <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-    </div>
+      Projects
+    </template>
 
-    <v-card-text>
+    <template #default>
+      <div class="d-flex justify-end mb-2">
+        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
+      </div>
       <div v-if="store.projects.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-code-braces" size="40" class="mb-2" />
         <p class="text-body-2">No projects added yet.</p>
@@ -42,77 +42,77 @@
           <v-icon icon="mdi-link" size="x-small" class="mr-1" />{{ project.url }}
         </div>
       </div>
-    </v-card-text>
+      <FormDialog
+        v-model="showDialog"
+        :title="editingId ? 'Edit Project' : 'Add Project'"
+        icon="mdi-code-braces"
+        :loading="saving"
+        :valid="formValid"
+        @confirm="saveProject"
+        @cancel="showDialog = false"
+      >
+        <v-row>
+          <v-col cols="12">
+            <v-text-field v-model="form.name" label="Project Name" variant="outlined" density="compact" :rules="[rules.required]" />
+          </v-col>
+          <v-col cols="12">
+            <v-textarea v-model="form.description" label="Description" variant="outlined" density="compact" rows="2" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.url" label="URL" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-switch v-model="form.isCurrent" label="Currently working on" color="primary" hide-details />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.startMonth" label="Start Month" type="number" variant="outlined" density="compact" min="1" max="12" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.startYear" label="Start Year" type="number" variant="outlined" density="compact" min="1900" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.endMonth" label="End Month" type="number" variant="outlined" density="compact" min="1" max="12" :disabled="form.isCurrent" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.endYear" label="End Year" type="number" variant="outlined" density="compact" min="1900" :disabled="form.isCurrent" />
+          </v-col>
+          <v-col cols="12">
+            <v-combobox
+              v-model="form.techStack"
+              label="Technologies"
+              variant="outlined"
+              density="compact"
+              multiple
+              chips
+              deletable-chips
+              small-chips
+              append-icon="mdi-plus"
+              hint="Type a technology and press Enter"
+              persistent-hint
+            />
+          </v-col>
+        </v-row>
+      </FormDialog>
 
-    <FormDialog
-      v-model="showDialog"
-      :title="editingId ? 'Edit Project' : 'Add Project'"
-      icon="mdi-code-braces"
-      :loading="saving"
-      :valid="formValid"
-      @confirm="saveProject"
-      @cancel="showDialog = false"
-    >
-      <v-row>
-        <v-col cols="12">
-          <v-text-field v-model="form.name" label="Project Name" variant="outlined" density="compact" :rules="[rules.required]" />
-        </v-col>
-        <v-col cols="12">
-          <v-textarea v-model="form.description" label="Description" variant="outlined" density="compact" rows="2" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.url" label="URL" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-switch v-model="form.isCurrent" label="Currently working on" color="primary" hide-details />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.startMonth" label="Start Month" type="number" variant="outlined" density="compact" min="1" max="12" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.startYear" label="Start Year" type="number" variant="outlined" density="compact" min="1900" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.endMonth" label="End Month" type="number" variant="outlined" density="compact" min="1" max="12" :disabled="form.isCurrent" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.endYear" label="End Year" type="number" variant="outlined" density="compact" min="1900" :disabled="form.isCurrent" />
-        </v-col>
-        <v-col cols="12">
-          <v-combobox
-            v-model="form.techStack"
-            label="Technologies"
-            variant="outlined"
-            density="compact"
-            multiple
-            chips
-            deletable-chips
-            small-chips
-            append-icon="mdi-plus"
-            hint="Type a technology and press Enter"
-            persistent-hint
-          />
-        </v-col>
-      </v-row>
-    </FormDialog>
-
-    <ConfirmDialog
-      v-model="deleteConfirm"
-      title="Delete Project"
-      variant="error"
-      confirm-text="Delete"
-      :loading="deleting"
-      @confirm="doDelete"
-    >
-      Are you sure you want to delete "{{ deleteTarget?.name }}"?
-    </ConfirmDialog>
-  </v-card>
+      <ConfirmDialog
+        v-model="deleteConfirm"
+        title="Delete Project"
+        variant="error"
+        confirm-text="Delete"
+        :loading="deleting"
+        @confirm="doDelete"
+      >
+        Are you sure you want to delete "{{ deleteTarget?.name }}"?
+      </ConfirmDialog>
+    </template>
+  </FormCard>
 </template>
 
 <script setup lang="ts">
 import { ref, reactive, computed } from 'vue'
 import type { IResumeProject } from '../../../models/resume-data.model'
 import { useResumeDataStore } from '../../../stores/resume-data.store'
+import FormCard from '../../forms/FormCard.vue'
 import FormDialog from '../../FormDialog.vue'
 import ConfirmDialog from '../../ConfirmDialog.vue'
 

--- a/src/main/webapp/src/components/profile/resume/PublicationCard.vue
+++ b/src/main/webapp/src/components/profile/resume/PublicationCard.vue
@@ -1,14 +1,14 @@
 <template>
-  <v-card elevation="0" border rounded="lg" class="mb-4">
-    <div class="d-flex align-center pa-4 pb-0">
+  <FormCard collapsible default-open class="mb-4">
+    <template #title>
       <v-icon icon="mdi-book-open-page-variant" color="primary" size="28" class="mr-3" />
-      <div class="flex-grow-1">
-        <div class="text-body-1 font-weight-medium">Publications</div>
-      </div>
-      <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-    </div>
+      Publications
+    </template>
 
-    <v-card-text>
+    <template #default>
+      <div class="d-flex justify-end mb-2">
+        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
+      </div>
       <div v-if="store.publications.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-book-open-page-variant-outline" size="40" class="mb-2" />
         <p class="text-body-2">No publications added yet.</p>
@@ -36,53 +36,53 @@
           </v-tooltip>
         </div>
       </div>
-    </v-card-text>
+      <FormDialog
+        v-model="showDialog"
+        :title="editingId ? 'Edit Publication' : 'Add Publication'"
+        icon="mdi-book-open-page-variant"
+        :loading="saving"
+        :valid="formValid"
+        @confirm="savePublication"
+        @cancel="showDialog = false"
+      >
+        <v-row>
+          <v-col cols="12">
+            <v-text-field v-model="form.title" label="Title" variant="outlined" density="compact" :rules="[rules.required]" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.publisher" label="Publisher" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.publicationDate" label="Publication Date" type="date" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="12">
+            <v-text-field v-model="form.url" label="URL" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="12">
+            <v-textarea v-model="form.description" label="Description" variant="outlined" density="compact" rows="2" />
+          </v-col>
+        </v-row>
+      </FormDialog>
 
-    <FormDialog
-      v-model="showDialog"
-      :title="editingId ? 'Edit Publication' : 'Add Publication'"
-      icon="mdi-book-open-page-variant"
-      :loading="saving"
-      :valid="formValid"
-      @confirm="savePublication"
-      @cancel="showDialog = false"
-    >
-      <v-row>
-        <v-col cols="12">
-          <v-text-field v-model="form.title" label="Title" variant="outlined" density="compact" :rules="[rules.required]" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.publisher" label="Publisher" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.publicationDate" label="Publication Date" type="date" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="12">
-          <v-text-field v-model="form.url" label="URL" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="12">
-          <v-textarea v-model="form.description" label="Description" variant="outlined" density="compact" rows="2" />
-        </v-col>
-      </v-row>
-    </FormDialog>
-
-    <ConfirmDialog
-      v-model="deleteConfirm"
-      title="Delete Publication"
-      variant="error"
-      confirm-text="Delete"
-      :loading="deleting"
-      @confirm="doDelete"
-    >
-      Are you sure you want to delete "{{ deleteTarget?.title }}"?
-    </ConfirmDialog>
-  </v-card>
+      <ConfirmDialog
+        v-model="deleteConfirm"
+        title="Delete Publication"
+        variant="error"
+        confirm-text="Delete"
+        :loading="deleting"
+        @confirm="doDelete"
+      >
+        Are you sure you want to delete "{{ deleteTarget?.title }}"?
+      </ConfirmDialog>
+    </template>
+  </FormCard>
 </template>
 
 <script setup lang="ts">
 import { ref, reactive, computed } from 'vue'
 import type { IResumePublication } from '../../../models/resume-data.model'
 import { useResumeDataStore } from '../../../stores/resume-data.store'
+import FormCard from '../../forms/FormCard.vue'
 import FormDialog from '../../FormDialog.vue'
 import ConfirmDialog from '../../ConfirmDialog.vue'
 

--- a/src/main/webapp/src/components/profile/resume/ResumeFileCard.vue
+++ b/src/main/webapp/src/components/profile/resume/ResumeFileCard.vue
@@ -1,10 +1,10 @@
 <template>
-  <v-card elevation="0" border rounded="lg" class="mb-4">
-    <v-card-title class="pa-4 pb-0 d-flex align-center">
+  <FormCard collapsible default-open class="mb-4">
+    <template #title>
       <v-icon icon="mdi-file-account" color="primary" class="mr-2" />
       <span class="text-body-1 font-weight-semibold">Resume File</span>
-    </v-card-title>
-    <v-card-text class="pa-4">
+    </template>
+    <template #default>
       <ProfileResumeField
         :profile-id="profileId"
         :resume-id="resumeId"
@@ -35,11 +35,12 @@
         <v-progress-circular indeterminate size="24" class="mr-3" />
         <span class="text-body-2">Extracting data from your resume...</span>
       </div>
-    </v-card-text>
-  </v-card>
+    </template>
+  </FormCard>
 </template>
 
 <script setup lang="ts">
+import FormCard from '../../forms/FormCard.vue'
 import ProfileResumeField from '../ProfileResumeField.vue'
 
 defineProps<{

--- a/src/main/webapp/src/components/profile/resume/ResumeTab.vue
+++ b/src/main/webapp/src/components/profile/resume/ResumeTab.vue
@@ -11,9 +11,7 @@
     <div v-for="we in store.workExperiences" :key="we.id">
       <WorkExperienceCard :work-experience="we" />
     </div>
-    <div v-for="edu in store.education" :key="edu.id">
-      <EducationCard :education-item="edu" />
-    </div>
+    <EducationCard />
 
     <ProjectCard />
     <CertificationCard />
@@ -182,7 +180,8 @@ interface AddableSection {
 
 const addableSections = computed<AddableSection[]>(() => {
   const sections: AddableSection[] = []
-  sections.push({ key: 'work-experience', label: 'Work Experience', icon: 'mdi-briefcase' })
+    sections.push({ key: 'work-experience', label: 'Work Experience', icon: 'mdi-briefcase' })
+  if (!store.education || store.education.length === 0) sections.push({ key: 'education', label: 'Education', icon: 'mdi-school' })
   if (!store.projects || store.projects.length === 0) sections.push({ key: 'projects', label: 'Projects', icon: 'mdi-code-braces' })
   if (!store.certifications || store.certifications.length === 0) sections.push({ key: 'certifications', label: 'Certifications', icon: 'mdi-certificate' })
   if (!store.languages || store.languages.length === 0) sections.push({ key: 'languages', label: 'Languages', icon: 'mdi-translate' })
@@ -224,6 +223,9 @@ function onResumeIdUpdate(value: string | undefined) {
 function onAddSection(sectionKey: string) {
   if (sectionKey === 'work-experience') {
     showAddWorkExperience.value = true
+    return
+  }
+  if (sectionKey === 'education') {
     return
   }
   showPreview.value = false

--- a/src/main/webapp/src/components/profile/resume/ResumeTab.vue
+++ b/src/main/webapp/src/components/profile/resume/ResumeTab.vue
@@ -15,54 +15,86 @@
       <EducationCard :education-item="edu" />
     </div>
 
-    <template v-if="store.projects && store.projects.length > 0">
-      <ProjectCard />
-    </template>
-    <template v-if="store.certifications && store.certifications.length > 0">
-      <CertificationCard />
-    </template>
-    <template v-if="store.languages && store.languages.length > 0">
-      <LanguageCard />
-    </template>
-    <template v-if="store.volunteerWork && store.volunteerWork.length > 0">
-      <VolunteerCard />
-    </template>
-    <template v-if="store.publications && store.publications.length > 0">
-      <PublicationCard />
-    </template>
-    <template v-if="store.awards && store.awards.length > 0">
-      <AwardCard />
-    </template>
-    <template v-if="store.affiliations && store.affiliations.length > 0">
-      <AffiliationCard />
-    </template>
+    <ProjectCard />
+    <CertificationCard />
+    <LanguageCard />
+    <VolunteerCard />
+    <PublicationCard />
+    <AwardCard />
+    <AffiliationCard />
 
-    <v-card
-      v-if="addableSections.length > 0"
-      elevation="0"
-      border
-      rounded="lg"
-      class="mb-4"
+    <FormDialog
+      v-model="showAddWorkExperience"
+      title="Add Work Experience"
+      icon="mdi-briefcase-plus"
+      :loading="savingNew"
+      :valid="workFormValid"
+      @confirm="saveNewWorkExperience"
+      @cancel="showAddWorkExperience = false"
     >
-      <div class="d-flex align-center pa-4 pb-0 mb-2">
-        <v-icon icon="mdi-puzzle-plus" color="primary" size="28" class="mr-3" />
-        <div class="text-body-1 font-weight-medium">Add Section</div>
-      </div>
-      <v-card-text class="pt-0">
-        <v-chip-group column>
-          <v-chip
+      <v-row>
+        <v-col cols="12" md="6">
+          <v-text-field
+            v-model="workForm.jobTitle"
+            label="Job Title"
+            variant="outlined"
+            density="compact"
+            :rules="[rules.required]"
+          />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-text-field
+            v-model="workForm.company"
+            label="Company"
+            variant="outlined"
+            density="compact"
+            :rules="[rules.required]"
+          />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-text-field v-model="workForm.location" label="Location" variant="outlined" density="compact" />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-switch v-model="workForm.isCurrent" label="I currently work here" color="primary" hide-details />
+        </v-col>
+        <v-col cols="6" md="3">
+          <v-text-field v-model="workForm.startMonth" label="Start Month" type="number" variant="outlined" density="compact" min="1" max="12" />
+        </v-col>
+        <v-col cols="6" md="3">
+          <v-text-field v-model="workForm.startYear" label="Start Year" type="number" variant="outlined" density="compact" min="1900" />
+        </v-col>
+        <v-col cols="6" md="3">
+          <v-text-field v-model="workForm.endMonth" label="End Month" type="number" variant="outlined" density="compact" min="1" max="12" :disabled="workForm.isCurrent" />
+        </v-col>
+        <v-col cols="6" md="3">
+          <v-text-field v-model="workForm.endYear" label="End Year" type="number" variant="outlined" density="compact" min="1900" :disabled="workForm.isCurrent" />
+        </v-col>
+      </v-row>
+    </FormDialog>
+
+    <Teleport to="body">
+      <v-menu>
+        <template #activator="{ props: menuProps }">
+          <v-btn
+            v-bind="menuProps"
+            icon="mdi-plus"
+            color="primary"
+            size="large"
+            class="add-section-fab"
+            elevation="4"
+          />
+        </template>
+        <v-list>
+          <v-list-item
             v-for="section in addableSections"
             :key="section.key"
             :prepend-icon="section.icon"
-            color="primary"
-            variant="outlined"
+            :title="section.label"
             @click="onAddSection(section.key)"
-          >
-            {{ section.label }}
-          </v-chip>
-        </v-chip-group>
-      </v-card-text>
-    </v-card>
+          />
+        </v-list>
+      </v-menu>
+    </Teleport>
 
     <ExtractionPreviewDialog
       v-model="showPreview"
@@ -79,7 +111,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, reactive, computed, onMounted, watch } from 'vue'
 import type { IProfile } from '../../../models'
 import { useResumeDataStore } from '../../../stores/resume-data.store'
 import ResumeFileCard from './ResumeFileCard.vue'
@@ -94,7 +126,8 @@ import PublicationCard from './PublicationCard.vue'
 import AwardCard from './AwardCard.vue'
 import AffiliationCard from './AffiliationCard.vue'
 import ExtractionPreviewDialog from './ExtractionPreviewDialog.vue'
-import type { IResumeExtractionResult } from '../../../models/resume-data.model'
+import FormDialog from '../../FormDialog.vue'
+import type { IResumeExtractionResult, IWorkExperience } from '../../../models/resume-data.model'
 
 const props = defineProps<{
   profile: IProfile
@@ -108,6 +141,38 @@ const emit = defineEmits<{
 const store = useResumeDataStore()
 const showPreview = ref(false)
 const savingExtracted = ref(false)
+const showAddWorkExperience = ref(false)
+const savingNew = ref(false)
+
+const workForm = reactive({
+  jobTitle: '',
+  company: '',
+  location: '',
+  startMonth: undefined as number | undefined,
+  startYear: undefined as number | undefined,
+  endMonth: undefined as number | undefined,
+  endYear: undefined as number | undefined,
+  isCurrent: false,
+})
+
+const rules = {
+  required: (v: string) => !!v || 'This field is required',
+}
+
+const workFormValid = computed(() => !!workForm.jobTitle && !!workForm.company)
+
+watch(showAddWorkExperience, (open) => {
+  if (open) {
+    workForm.jobTitle = ''
+    workForm.company = ''
+    workForm.location = ''
+    workForm.startMonth = undefined
+    workForm.startYear = undefined
+    workForm.endMonth = undefined
+    workForm.endYear = undefined
+    workForm.isCurrent = false
+  }
+})
 
 interface AddableSection {
   key: string
@@ -117,6 +182,7 @@ interface AddableSection {
 
 const addableSections = computed<AddableSection[]>(() => {
   const sections: AddableSection[] = []
+  sections.push({ key: 'work-experience', label: 'Work Experience', icon: 'mdi-briefcase' })
   if (!store.projects || store.projects.length === 0) sections.push({ key: 'projects', label: 'Projects', icon: 'mdi-code-braces' })
   if (!store.certifications || store.certifications.length === 0) sections.push({ key: 'certifications', label: 'Certifications', icon: 'mdi-certificate' })
   if (!store.languages || store.languages.length === 0) sections.push({ key: 'languages', label: 'Languages', icon: 'mdi-translate' })
@@ -156,6 +222,30 @@ function onResumeIdUpdate(value: string | undefined) {
 }
 
 function onAddSection(sectionKey: string) {
+  if (sectionKey === 'work-experience') {
+    showAddWorkExperience.value = true
+    return
+  }
   showPreview.value = false
 }
+
+async function saveNewWorkExperience() {
+  savingNew.value = true
+  try {
+    const dto: IWorkExperience = { ...workForm }
+    await store.createWorkExperience(dto)
+    showAddWorkExperience.value = false
+  } finally {
+    savingNew.value = false
+  }
+}
 </script>
+
+<style scoped>
+.add-section-fab {
+  position: fixed;
+  bottom: 80px;
+  right: 20px;
+  z-index: 999;
+}
+</style>

--- a/src/main/webapp/src/components/profile/resume/SkillsCard.vue
+++ b/src/main/webapp/src/components/profile/resume/SkillsCard.vue
@@ -1,16 +1,14 @@
 <template>
-  <v-card elevation="0" border rounded="lg" class="mb-4">
-    <div class="d-flex align-center pa-4 pb-0">
+  <FormCard collapsible default-open class="mb-4">
+    <template #title>
       <v-icon icon="mdi-lightning-bolt" color="primary" size="28" class="mr-3" />
-      <div class="flex-grow-1">
-        <div class="text-body-1 font-weight-medium">
-          Skills
-        </div>
-      </div>
-      <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="showAddForm = true" />
-    </div>
+      Skills
+    </template>
 
-    <v-card-text>
+    <template #default>
+      <div class="d-flex justify-end mb-2">
+        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="showAddForm = true" />
+      </div>
       <div v-if="skillGroups.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-lightning-bolt-outline" size="40" class="mb-2" />
         <p class="text-body-2">No skills added yet. Extract from your resume or add manually.</p>
@@ -43,47 +41,47 @@
           </v-chip>
         </div>
       </div>
-    </v-card-text>
-
-    <FormDialog
-      v-model="showFormDialog"
-      :title="editingId ? 'Edit Skill Group' : 'Add Skill Group'"
-      icon="mdi-lightning-bolt"
-      :loading="saving"
-      :valid="formValid"
-      @confirm="saveGroup"
-      @cancel="showFormDialog = false"
-    >
-      <v-text-field
-        v-model="form.category"
-        label="Category"
-        variant="outlined"
-        density="compact"
-        :rules="[rules.required]"
-        placeholder="e.g., Programming Languages"
-        class="mb-3"
-      />
-      <v-combobox
-        v-model="form.skills"
-        label="Skills"
-        variant="outlined"
-        density="compact"
-        multiple
-        chips
-        deletable-chips
-        small-chips
-        append-icon="mdi-plus"
-        hint="Type a skill and press Enter"
-        persistent-hint
-      />
-    </FormDialog>
-  </v-card>
+      <FormDialog
+        v-model="showFormDialog"
+        :title="editingId ? 'Edit Skill Group' : 'Add Skill Group'"
+        icon="mdi-lightning-bolt"
+        :loading="saving"
+        :valid="formValid"
+        @confirm="saveGroup"
+        @cancel="showFormDialog = false"
+      >
+        <v-text-field
+          v-model="form.category"
+          label="Category"
+          variant="outlined"
+          density="compact"
+          :rules="[rules.required]"
+          placeholder="e.g., Programming Languages"
+          class="mb-3"
+        />
+        <v-combobox
+          v-model="form.skills"
+          label="Skills"
+          variant="outlined"
+          density="compact"
+          multiple
+          chips
+          deletable-chips
+          small-chips
+          append-icon="mdi-plus"
+          hint="Type a skill and press Enter"
+          persistent-hint
+        />
+      </FormDialog>
+    </template>
+  </FormCard>
 </template>
 
 <script setup lang="ts">
 import { ref, reactive, computed } from 'vue'
 import type { ISkillGroup } from '../../../models/resume-data.model'
 import { useResumeDataStore } from '../../../stores/resume-data.store'
+import FormCard from '../../forms/FormCard.vue'
 import FormDialog from '../../FormDialog.vue'
 
 const store = useResumeDataStore()

--- a/src/main/webapp/src/components/profile/resume/SkillsCard.vue
+++ b/src/main/webapp/src/components/profile/resume/SkillsCard.vue
@@ -14,10 +14,26 @@
         <p class="text-body-2">No skills added yet. Extract from your resume or add manually.</p>
       </div>
 
-      <div v-for="sg in skillGroups" :key="sg.id" class="mb-3">
+      <div v-for="(sg, index) in skillGroups" :key="sg.id" class="mb-3">
         <div class="d-flex align-center mb-1">
           <span class="text-subtitle-2 font-weight-medium">{{ sg.category }}</span>
           <v-spacer />
+          <v-menu v-model="addSkillMenu[sg.id || index]" :close-on-content-click="false">
+            <template #activator="{ props }">
+              <v-btn v-bind="props" icon="mdi-plus" variant="text" size="x-small" color="primary" class="mr-1" />
+            </template>
+            <v-card min-width="250" class="pa-2">
+              <v-text-field
+                v-model="newSkillText"
+                label="New skill"
+                variant="outlined"
+                density="compact"
+                hide-details
+                @keyup.enter="confirmAddSkill(sg)"
+              />
+              <v-btn color="primary" size="small" class="mt-2" @click="confirmAddSkill(sg)">Add</v-btn>
+            </v-card>
+          </v-menu>
           <v-tooltip text="Edit" location="top">
             <template #activator="{ props: tp }">
               <v-btn v-bind="tp" icon="mdi-pencil" variant="text" size="x-small" color="primary" class="mr-1" @click="editSkillGroup(sg)" />
@@ -36,6 +52,8 @@
             size="small"
             color="primary"
             variant="outlined"
+            closable
+            @click:close="deleteSkill(sg, i)"
           >
             {{ skill }}
           </v-chip>
@@ -58,19 +76,6 @@
           :rules="[rules.required]"
           placeholder="e.g., Programming Languages"
           class="mb-3"
-        />
-        <v-combobox
-          v-model="form.skills"
-          label="Skills"
-          variant="outlined"
-          density="compact"
-          multiple
-          chips
-          deletable-chips
-          small-chips
-          append-icon="mdi-plus"
-          hint="Type a skill and press Enter"
-          persistent-hint
         />
       </FormDialog>
     </template>
@@ -113,6 +118,9 @@ const rules = {
 
 const formValid = computed(() => !!form.category)
 
+const addSkillMenu = reactive<Record<string, boolean>>({})
+const newSkillText = ref('')
+
 function editSkillGroup(sg: ISkillGroup) {
   editingId.value = sg.id || null
   form.category = sg.category || ''
@@ -141,6 +149,24 @@ async function saveGroup() {
 async function deleteGroup(sg: ISkillGroup) {
   if (sg.id) {
     await store.deleteSkillGroup(sg.id)
+  }
+}
+
+async function deleteSkill(sg: ISkillGroup, skillIndex: number) {
+  sg.skills?.splice(skillIndex, 1)
+  if (sg.id) {
+    await store.updateSkillGroup(sg.id, { category: sg.category, skills: sg.skills })
+  }
+}
+
+function confirmAddSkill(sg: ISkillGroup) {
+  const skill = newSkillText.value.trim()
+  if (!skill) return
+  if (!sg.skills) sg.skills = []
+  sg.skills.push(skill)
+  newSkillText.value = ''
+  if (sg.id) {
+    store.updateSkillGroup(sg.id, { category: sg.category, skills: sg.skills })
   }
 }
 </script>

--- a/src/main/webapp/src/components/profile/resume/VolunteerCard.vue
+++ b/src/main/webapp/src/components/profile/resume/VolunteerCard.vue
@@ -1,14 +1,14 @@
 <template>
-  <v-card elevation="0" border rounded="lg" class="mb-4">
-    <div class="d-flex align-center pa-4 pb-0">
+  <FormCard collapsible default-open class="mb-4">
+    <template #title>
       <v-icon icon="mdi-hand-heart" color="primary" size="28" class="mr-3" />
-      <div class="flex-grow-1">
-        <div class="text-body-1 font-weight-medium">Volunteer Work</div>
-      </div>
-      <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-    </div>
+      Volunteer Work
+    </template>
 
-    <v-card-text>
+    <template #default>
+      <div class="d-flex justify-end mb-2">
+        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
+      </div>
       <div v-if="store.volunteerWork.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-hand-heart-outline" size="40" class="mb-2" />
         <p class="text-body-2">No volunteer work added yet.</p>
@@ -39,65 +39,65 @@
           {{ vw.description.substring(0, 120) }}{{ vw.description.length > 120 ? '...' : '' }}
         </div>
       </div>
-    </v-card-text>
+      <FormDialog
+        v-model="showDialog"
+        :title="editingId ? 'Edit Volunteer Work' : 'Add Volunteer Work'"
+        icon="mdi-hand-heart"
+        :loading="saving"
+        :valid="formValid"
+        @confirm="saveVolunteerWork"
+        @cancel="showDialog = false"
+      >
+        <v-row>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.role" label="Role" variant="outlined" density="compact" :rules="[rules.required]" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.organization" label="Organization" variant="outlined" density="compact" :rules="[rules.required]" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.location" label="Location" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-switch v-model="form.isCurrent" label="Currently volunteering" color="primary" hide-details />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.startMonth" label="Start Month" type="number" variant="outlined" density="compact" min="1" max="12" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.startYear" label="Start Year" type="number" variant="outlined" density="compact" min="1900" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.endMonth" label="End Month" type="number" variant="outlined" density="compact" min="1" max="12" :disabled="form.isCurrent" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.endYear" label="End Year" type="number" variant="outlined" density="compact" min="1900" :disabled="form.isCurrent" />
+          </v-col>
+          <v-col cols="12">
+            <v-textarea v-model="form.description" label="Description" variant="outlined" density="compact" rows="3" />
+          </v-col>
+        </v-row>
+      </FormDialog>
 
-    <FormDialog
-      v-model="showDialog"
-      :title="editingId ? 'Edit Volunteer Work' : 'Add Volunteer Work'"
-      icon="mdi-hand-heart"
-      :loading="saving"
-      :valid="formValid"
-      @confirm="saveVolunteerWork"
-      @cancel="showDialog = false"
-    >
-      <v-row>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.role" label="Role" variant="outlined" density="compact" :rules="[rules.required]" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.organization" label="Organization" variant="outlined" density="compact" :rules="[rules.required]" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.location" label="Location" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-switch v-model="form.isCurrent" label="Currently volunteering" color="primary" hide-details />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.startMonth" label="Start Month" type="number" variant="outlined" density="compact" min="1" max="12" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.startYear" label="Start Year" type="number" variant="outlined" density="compact" min="1900" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.endMonth" label="End Month" type="number" variant="outlined" density="compact" min="1" max="12" :disabled="form.isCurrent" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.endYear" label="End Year" type="number" variant="outlined" density="compact" min="1900" :disabled="form.isCurrent" />
-        </v-col>
-        <v-col cols="12">
-          <v-textarea v-model="form.description" label="Description" variant="outlined" density="compact" rows="3" />
-        </v-col>
-      </v-row>
-    </FormDialog>
-
-    <ConfirmDialog
-      v-model="deleteConfirm"
-      title="Delete Volunteer Work"
-      variant="error"
-      confirm-text="Delete"
-      :loading="deleting"
-      @confirm="doDelete"
-    >
-      Are you sure you want to delete "{{ deleteTarget?.role }}" at {{ deleteTarget?.organization }}?
-    </ConfirmDialog>
-  </v-card>
+      <ConfirmDialog
+        v-model="deleteConfirm"
+        title="Delete Volunteer Work"
+        variant="error"
+        confirm-text="Delete"
+        :loading="deleting"
+        @confirm="doDelete"
+      >
+        Are you sure you want to delete "{{ deleteTarget?.role }}" at {{ deleteTarget?.organization }}?
+      </ConfirmDialog>
+    </template>
+  </FormCard>
 </template>
 
 <script setup lang="ts">
 import { ref, reactive, computed } from 'vue'
 import type { IVolunteerWork } from '../../../models/resume-data.model'
 import { useResumeDataStore } from '../../../stores/resume-data.store'
+import FormCard from '../../forms/FormCard.vue'
 import FormDialog from '../../FormDialog.vue'
 import ConfirmDialog from '../../ConfirmDialog.vue'
 

--- a/src/main/webapp/src/components/profile/resume/WorkExperienceCard.vue
+++ b/src/main/webapp/src/components/profile/resume/WorkExperienceCard.vue
@@ -8,10 +8,18 @@
     <template #title>
       <div class="w-100">
         <div class="d-flex align-center w-100">
-          <v-icon icon="mdi-briefcase" color="primary" size="28" class="mr-3 flex-shrink-0" />
-          <span class="text-body-1 font-weight-medium">{{ workExperience.jobTitle || 'Untitled' }}</span>
-          <span class="text-caption text-medium-emphasis mx-1">&middot;</span>
-          <span class="text-caption text-medium-emphasis flex-grow-1">{{ workExperience.company }}</span>
+          <v-icon icon="mdi-briefcase" color="primary" size="24" class="mr-2 flex-shrink-0" />
+          <div class="flex-grow-1">
+            <div class="text-body-1 font-weight-medium">
+              {{ workExperience.jobTitle || 'Untitled' }}
+              <span class="text-medium-emphasis"> at </span>
+              {{ workExperience.company || 'Unknown Company' }}
+            </div>
+            <div class="text-caption text-medium-emphasis">
+              <template v-if="workExperience.location">{{ workExperience.location }} &middot; </template>
+              {{ dateRange }}
+            </div>
+          </div>
           <v-tooltip text="Edit" location="top">
             <template #activator="{ props: tp }">
               <v-btn v-bind="tp" icon="mdi-pencil" variant="text" size="small" color="primary" @click="editDialog = true" />
@@ -22,10 +30,6 @@
               <v-btn v-bind="tp" icon="mdi-delete" variant="text" size="small" color="error" @click="confirmDelete = true" />
             </template>
           </v-tooltip>
-        </div>
-        <div class="text-caption text-medium-emphasis ml-10">
-          <template v-if="workExperience.location">{{ workExperience.location }} <span class="mx-1">&middot;</span> </template>
-          {{ dateRange }}
         </div>
       </div>
     </template>

--- a/src/main/webapp/src/components/profile/resume/WorkExperienceCard.vue
+++ b/src/main/webapp/src/components/profile/resume/WorkExperienceCard.vue
@@ -1,124 +1,119 @@
 <template>
-  <v-card
+  <FormCard
     v-if="workExperience"
-    elevation="0"
-    border
-    rounded="lg"
+    collapsible
+    default-open
     class="mb-4"
   >
-    <div class="d-flex align-center pa-4 pb-0">
-      <v-icon icon="mdi-briefcase" color="primary" size="28" class="mr-3" />
-      <div class="flex-grow-1">
-        <div class="text-body-1 font-weight-medium">
-          {{ workExperience.jobTitle || 'Untitled' }}
+    <template #title>
+      <div class="w-100">
+        <div class="d-flex align-center w-100">
+          <v-icon icon="mdi-briefcase" color="primary" size="28" class="mr-3 flex-shrink-0" />
+          <span class="text-body-1 font-weight-medium">{{ workExperience.jobTitle || 'Untitled' }}</span>
+          <span class="text-caption text-medium-emphasis mx-1">&middot;</span>
+          <span class="text-caption text-medium-emphasis flex-grow-1">{{ workExperience.company }}</span>
+          <v-tooltip text="Edit" location="top">
+            <template #activator="{ props: tp }">
+              <v-btn v-bind="tp" icon="mdi-pencil" variant="text" size="small" color="primary" @click="editDialog = true" />
+            </template>
+          </v-tooltip>
+          <v-tooltip text="Delete" location="top">
+            <template #activator="{ props: tp }">
+              <v-btn v-bind="tp" icon="mdi-delete" variant="text" size="small" color="error" @click="confirmDelete = true" />
+            </template>
+          </v-tooltip>
         </div>
-        <div class="text-caption text-medium-emphasis">
-          {{ workExperience.company }}
-          <template v-if="workExperience.location"> &middot; {{ workExperience.location }} </template>
+        <div class="text-caption text-medium-emphasis ml-10">
+          <template v-if="workExperience.location">{{ workExperience.location }} <span class="mx-1">&middot;</span> </template>
+          {{ dateRange }}
         </div>
       </div>
-      <div class="d-flex ga-1">
-        <v-tooltip text="Edit" location="top">
-          <template #activator="{ props: tp }">
-            <v-btn v-bind="tp" icon="mdi-pencil" variant="text" size="small" color="primary" @click="editDialog = true" />
-          </template>
-        </v-tooltip>
-        <v-tooltip text="Delete" location="top">
-          <template #activator="{ props: tp }">
-            <v-btn v-bind="tp" icon="mdi-delete" variant="text" size="small" color="error" @click="confirmDelete = true" />
-          </template>
-        </v-tooltip>
-      </div>
-    </div>
+    </template>
 
-    <v-card-text class="pt-2 pb-0">
-      <div v-if="workExperience.startYear || workExperience.endYear" class="text-caption text-medium-emphasis mb-2">
-        {{ dateRange }}
-      </div>
+    <template #default>
       <BulletEditor
         v-if="workExperience.id"
         :bullets="workExperience.bullets || []"
         @update:bullets="onUpdateBullets"
       />
-    </v-card-text>
+      <FormDialog
+        v-model="editDialog"
+        title="Edit Work Experience"
+        icon="mdi-briefcase-edit"
+        :loading="saving"
+        :valid="formValid"
+        @confirm="saveEdit"
+        @cancel="editDialog = false"
+      >
+        <v-row>
+          <v-col cols="12" md="6">
+            <v-text-field
+              v-model="form.jobTitle"
+              label="Job Title"
+              variant="outlined"
+              density="compact"
+              :rules="[rules.required]"
+            />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field
+              v-model="form.company"
+              label="Company"
+              variant="outlined"
+              density="compact"
+              :rules="[rules.required]"
+            />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.location" label="Location" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-switch v-model="form.isCurrent" label="I currently work here" color="primary" hide-details />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.startMonth" label="Start Month" type="number" variant="outlined" density="compact" min="1" max="12" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.startYear" label="Start Year" type="number" variant="outlined" density="compact" min="1900" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field
+              v-model="form.endMonth"
+              label="End Month"
+              type="number"
+              variant="outlined"
+              density="compact"
+              min="1"
+              max="12"
+              :disabled="form.isCurrent"
+            />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field
+              v-model="form.endYear"
+              label="End Year"
+              type="number"
+              variant="outlined"
+              density="compact"
+              min="1900"
+              :disabled="form.isCurrent"
+            />
+          </v-col>
+        </v-row>
+      </FormDialog>
 
-    <FormDialog
-      v-model="editDialog"
-      title="Edit Work Experience"
-      icon="mdi-briefcase-edit"
-      :loading="saving"
-      :valid="formValid"
-      @confirm="saveEdit"
-      @cancel="editDialog = false"
-    >
-      <v-row>
-        <v-col cols="12" md="6">
-          <v-text-field
-            v-model="form.jobTitle"
-            label="Job Title"
-            variant="outlined"
-            density="compact"
-            :rules="[rules.required]"
-          />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field
-            v-model="form.company"
-            label="Company"
-            variant="outlined"
-            density="compact"
-            :rules="[rules.required]"
-          />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="form.location" label="Location" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-switch v-model="form.isCurrent" label="I currently work here" color="primary" hide-details />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.startMonth" label="Start Month" type="number" variant="outlined" density="compact" min="1" max="12" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="form.startYear" label="Start Year" type="number" variant="outlined" density="compact" min="1900" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field
-            v-model="form.endMonth"
-            label="End Month"
-            type="number"
-            variant="outlined"
-            density="compact"
-            min="1"
-            max="12"
-            :disabled="form.isCurrent"
-          />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field
-            v-model="form.endYear"
-            label="End Year"
-            type="number"
-            variant="outlined"
-            density="compact"
-            min="1900"
-            :disabled="form.isCurrent"
-          />
-        </v-col>
-      </v-row>
-    </FormDialog>
-
-    <ConfirmDialog
-      v-model="confirmDelete"
-      title="Delete Work Experience"
-      variant="error"
-      confirm-text="Delete"
-      :loading="deleting"
-      @confirm="doDelete"
-    >
-      Are you sure you want to delete this work experience? This action cannot be undone.
-    </ConfirmDialog>
-  </v-card>
+      <ConfirmDialog
+        v-model="confirmDelete"
+        title="Delete Work Experience"
+        variant="error"
+        confirm-text="Delete"
+        :loading="deleting"
+        @confirm="doDelete"
+      >
+        Are you sure you want to delete this work experience? This action cannot be undone.
+      </ConfirmDialog>
+    </template>
+  </FormCard>
 </template>
 
 <script setup lang="ts">
@@ -126,6 +121,7 @@ import { ref, reactive, computed, watch } from 'vue'
 import type { IWorkExperience, IWorkExperienceBullet } from '../../../models/resume-data.model'
 import { useResumeDataStore } from '../../../stores/resume-data.store'
 import BulletEditor from './BulletEditor.vue'
+import FormCard from '../../forms/FormCard.vue'
 import FormDialog from '../../FormDialog.vue'
 import ConfirmDialog from '../../ConfirmDialog.vue'
 

--- a/src/main/webapp/src/views/profile/ProfileView.ts
+++ b/src/main/webapp/src/views/profile/ProfileView.ts
@@ -66,6 +66,11 @@ export default defineComponent({
         icon: 'mdi-account'
       },
       {
+        value: 'resume',
+        title: 'Resume',
+        icon: 'mdi-file-account'
+      },
+      {
         value: 'password',
         title: 'Password & Security',
         icon: 'mdi-lock'
@@ -79,11 +84,6 @@ export default defineComponent({
         value: 'api',
         title: 'API & Webhooks',
         icon: 'mdi-api'
-      },
-      {
-        value: 'resume',
-        title: 'Resume',
-        icon: 'mdi-file-account'
       }
     ]
 


### PR DESCRIPTION
## Phase 5 — Skills Section Redesign

### Changes in `SkillsCard.vue`:
- **Removed** the confusing `append-icon="mdi-plus"` from the combobox (and removed the skills combobox entirely from the FormDialog — skills are now managed inline)
- **Closable chips** — each skill chip now has a delete (X) icon that removes the skill and persists via API
- **"+" popover** — each skill group row has a new `mdi-plus` button that opens a small `v-menu` popover with a text field to add a new skill inline
- **New functions** — `deleteSkill()` and `confirmAddSkill()` for inline skill management
- **FormDialog simplified** — only the category text field remains

### Verification:
- `npm run type-check` ✅ passes
- `npm run lint` — no new errors (pre-existing issues only)