### PR TITLE
Enhance work experience section in profile resume

### DIFF
--- a/src/main/webapp/src/components/forms/FormCard.vue
+++ b/src/main/webapp/src/components/forms/FormCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card elevation="0" border rounded="lg">
     <v-card-title class="pa-5 pb-4 text-body-1 font-weight-semibold d-flex align-center">
-      <span class="flex-grow-1">
+      <span class="flex-grow-1 d-flex align-center">
         <slot name="title" />
       </span>
       <v-btn
@@ -12,7 +12,7 @@
         size="small"
         :aria-label="isOpen ? 'Collapse section' : 'Expand section'"
         :aria-expanded="isOpen"
-        @click="isOpen = !isOpen"
+        @click="toggle"
       />
     </v-card-title>
     <v-expand-transition>
@@ -33,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
 defineOptions({
   name: 'FormCard',
@@ -43,7 +43,26 @@ const props = defineProps({
   collapsible: { type: Boolean, default: true },
   defaultOpen: { type: Boolean, default: true },
   showToggle: { type: Boolean, default: true },
+  modelValue: { type: Boolean, default: undefined },
 })
 
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+}>()
+
 const isOpen = ref(props.defaultOpen)
+
+watch(() => props.modelValue, (val) => {
+  if (val !== undefined) {
+    isOpen.value = val
+  }
+})
+
+function toggle() {
+  const next = !isOpen.value
+  isOpen.value = next
+  if (props.modelValue !== undefined) {
+    emit('update:modelValue', next)
+  }
+}
 </script>

--- a/src/main/webapp/src/components/profile/resume/AffiliationCard.vue
+++ b/src/main/webapp/src/components/profile/resume/AffiliationCard.vue
@@ -1,14 +1,20 @@
 <template>
-  <FormCard collapsible default-open class="mb-4">
+  <FormCard v-model="cardOpen" collapsible default-open class="mb-4">
     <template #title>
       <v-icon icon="mdi-account-group" color="primary" size="28" class="mr-3" />
       Professional Affiliations
+      <v-spacer />
+      <v-btn
+        v-if="cardOpen"
+        icon="mdi-plus"
+        variant="text"
+        color="primary"
+        size="small"
+        @click.stop="openAdd"
+      />
     </template>
 
     <template #default>
-      <div class="d-flex justify-end mb-2">
-        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-      </div>
       <div v-if="store.affiliations.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-account-group-outline" size="40" class="mb-2" />
         <p class="text-body-2">No professional affiliations added yet.</p>
@@ -96,6 +102,7 @@ import ConfirmDialog from '../../ConfirmDialog.vue'
 
 const store = useResumeDataStore()
 
+const cardOpen = ref(true)
 const showDialog = ref(false)
 const saving = ref(false)
 const editingId = ref<string | null>(null)

--- a/src/main/webapp/src/components/profile/resume/AwardCard.vue
+++ b/src/main/webapp/src/components/profile/resume/AwardCard.vue
@@ -1,14 +1,20 @@
 <template>
-  <FormCard collapsible default-open class="mb-4">
+  <FormCard v-model="cardOpen" collapsible default-open class="mb-4">
     <template #title>
       <v-icon icon="mdi-trophy" color="primary" size="28" class="mr-3" />
       Awards
+      <v-spacer />
+      <v-btn
+        v-if="cardOpen"
+        icon="mdi-plus"
+        variant="text"
+        color="primary"
+        size="small"
+        @click.stop="openAdd"
+      />
     </template>
 
     <template #default>
-      <div class="d-flex justify-end mb-2">
-        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-      </div>
       <div v-if="store.awards.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-trophy-outline" size="40" class="mb-2" />
         <p class="text-body-2">No awards added yet.</p>
@@ -88,6 +94,7 @@ import ConfirmDialog from '../../ConfirmDialog.vue'
 
 const store = useResumeDataStore()
 
+const cardOpen = ref(true)
 const showDialog = ref(false)
 const saving = ref(false)
 const editingId = ref<string | null>(null)

--- a/src/main/webapp/src/components/profile/resume/BulletEditor.vue
+++ b/src/main/webapp/src/components/profile/resume/BulletEditor.vue
@@ -30,33 +30,36 @@
         />
       </template>
     </v-list-item>
-    <v-btn
-      variant="text"
-      color="primary"
-      size="small"
-      prepend-icon="mdi-plus"
-      class="mt-1"
-      @click="addBullet"
-    >
-      Add bullet point
-    </v-btn>
-    <div v-if="dirty" class="d-flex ga-2 mt-2">
+    <div class="d-flex ga-2 mt-1 align-center">
       <v-btn
-        color="success"
-        prepend-icon="mdi-content-save"
+        variant="text"
+        color="primary"
         size="small"
-        @click="emitBullets"
+        prepend-icon="mdi-plus"
+        @click="addBullet"
       >
-        Save
+        Add bullet point
       </v-btn>
-      <v-btn
-        color="warning"
-        prepend-icon="mdi-undo"
-        size="small"
-        @click="revertBullets"
-      >
-        Revert
-      </v-btn>
+      <template v-if="dirty">
+        <v-btn
+          variant="text"
+          color="success"
+          prepend-icon="mdi-content-save"
+          size="small"
+          @click="emitBullets"
+        >
+          Save
+        </v-btn>
+        <v-btn
+          variant="text"
+          color="warning"
+          prepend-icon="mdi-undo"
+          size="small"
+          @click="revertBullets"
+        >
+          Revert
+        </v-btn>
+      </template>
     </div>
   </v-list>
 </template>

--- a/src/main/webapp/src/components/profile/resume/BulletEditor.vue
+++ b/src/main/webapp/src/components/profile/resume/BulletEditor.vue
@@ -1,71 +1,23 @@
 <template>
-  <v-list class="bullet-editor bg-transparent pa-0" density="compact">
-    <v-list-item
-      v-for="(bullet, index) in localBullets"
-      :key="index"
-      class="bullet-item pa-0 mb-1"
-    >
-      <template #prepend>
-        <span class="bullet-number text-caption text-medium-emphasis mr-1">{{ index + 1 }}.</span>
-      </template>
-      <v-textarea
-        :model-value="bullet.content"
-        variant="outlined"
-        density="compact"
-        hide-details
-        auto-grow
-        rows="2"
-        placeholder="Describe an accomplishment or responsibility..."
-        class="bullet-input"
-        @update:model-value="updateBullet(index, $event as string)"
-      />
-      <template #append>
-        <v-btn
-          icon="mdi-close"
-          variant="text"
-          size="x-small"
-          color="error"
-          class="ml-1"
-          @click="removeBullet(index)"
-        />
-      </template>
-    </v-list-item>
-    <div class="d-flex ga-2 mt-1 align-center">
-      <v-btn
-        variant="text"
-        color="primary"
-        size="small"
-        prepend-icon="mdi-plus"
-        @click="addBullet"
+  <div class="bullet-editor">
+    <div v-for="(bullet, index) in bullets" :key="index" class="d-flex align-start mb-1">
+      <span class="bullet-number text-caption text-medium-emphasis mr-1 flex-shrink-0"
+        >{{ index + 1 }}.</span
       >
-        Add bullet point
-      </v-btn>
-      <template v-if="dirty">
-        <v-btn
-          variant="text"
-          color="success"
-          prepend-icon="mdi-content-save"
-          size="small"
-          @click="emitBullets"
-        >
-          Save
-        </v-btn>
-        <v-btn
-          variant="text"
-          color="warning"
-          prepend-icon="mdi-undo"
-          size="small"
-          @click="revertBullets"
-        >
-          Revert
-        </v-btn>
-      </template>
+      <span class="flex-grow-1 text-body-2 text-justify">{{ bullet.content }}</span>
+      <v-btn
+        icon="mdi-close"
+        variant="text"
+        size="x-small"
+        color="error"
+        class="flex-shrink-0 ml-1"
+        @click="removeBullet(index)"
+      />
     </div>
-  </v-list>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
 import type { IWorkExperienceBullet } from '../../../models/resume-data.model'
 
 const props = defineProps<{
@@ -76,72 +28,17 @@ const emit = defineEmits<{
   'update:bullets': [value: IWorkExperienceBullet[]]
 }>()
 
-const localBullets = ref<IWorkExperienceBullet[]>(props.bullets.length
-  ? [...props.bullets]
-  : [{ content: '', displayOrder: 0 }]
-)
-
-const dirty = computed(() => {
-  const current = localBullets.value
-  const original = props.bullets
-  const effectiveCurrent = current.filter(b => b.content)
-  const effectiveOriginal = original.filter(b => b.content)
-  if (effectiveCurrent.length !== effectiveOriginal.length) return true
-  return effectiveCurrent.some((b, i) => b.content !== effectiveOriginal[i]?.content)
-})
-
-watch(
-  () => props.bullets,
-  (val) => {
-    if (val.length === 0) {
-      localBullets.value = [{ content: '', displayOrder: 0 }]
-    } else {
-      localBullets.value = val.map((b, i) => ({ ...b, displayOrder: i }))
-    }
-  },
-  { deep: true }
-)
-
-function emitBullets() {
-  emit('update:bullets', localBullets.value.map((b, i) => ({
-    ...b,
-    displayOrder: i,
-  })))
-}
-
-function revertBullets() {
-  if (props.bullets.length === 0) {
-    localBullets.value = [{ content: '', displayOrder: 0 }]
-  } else {
-    localBullets.value = props.bullets.map((b, i) => ({ ...b, displayOrder: i }))
-  }
-}
-
-function addBullet() {
-  localBullets.value.push({ content: '', displayOrder: localBullets.value.length })
-}
-
 function removeBullet(index: number) {
-  localBullets.value.splice(index, 1)
-  if (localBullets.value.length === 0) {
-    localBullets.value.push({ content: '', displayOrder: 0 })
-  }
-}
-
-function updateBullet(index: number, content: string) {
-  if (localBullets.value[index]) {
-    localBullets.value[index].content = content
-  }
+  const updated = props.bullets.filter((_, i) => i !== index)
+  emit(
+    'update:bullets',
+    updated.map((b, i) => ({ ...b, displayOrder: i }))
+  )
 }
 </script>
 
 <style scoped>
-.bullet-editor :deep(.v-list-item__prepend) {
-  align-self: flex-start;
-  padding-top: 16px;
-}
 .bullet-number {
-  min-width: 20px;
-  line-height: 40px;
+  line-height: 1.5;
 }
 </style>

--- a/src/main/webapp/src/components/profile/resume/CertificationCard.vue
+++ b/src/main/webapp/src/components/profile/resume/CertificationCard.vue
@@ -1,14 +1,20 @@
 <template>
-  <FormCard collapsible default-open class="mb-4">
+  <FormCard v-model="cardOpen" collapsible default-open class="mb-4">
     <template #title>
       <v-icon icon="mdi-certificate" color="primary" size="28" class="mr-3" />
       Certifications
+      <v-spacer />
+      <v-btn
+        v-if="cardOpen"
+        icon="mdi-plus"
+        variant="text"
+        color="primary"
+        size="small"
+        @click.stop="openAdd"
+      />
     </template>
 
     <template #default>
-      <div class="d-flex justify-end mb-2">
-        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-      </div>
       <div v-if="store.certifications.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-certificate-outline" size="40" class="mb-2" />
         <p class="text-body-2">No certifications added yet.</p>
@@ -88,6 +94,7 @@ import ConfirmDialog from '../../ConfirmDialog.vue'
 
 const store = useResumeDataStore()
 
+const cardOpen = ref(true)
 const showDialog = ref(false)
 const saving = ref(false)
 const editingId = ref<string | null>(null)

--- a/src/main/webapp/src/components/profile/resume/EducationCard.vue
+++ b/src/main/webapp/src/components/profile/resume/EducationCard.vue
@@ -1,14 +1,20 @@
 <template>
-  <FormCard collapsible default-open class="mb-4">
+  <FormCard v-model="cardOpen" collapsible default-open class="mb-4">
     <template #title>
       <v-icon icon="mdi-school" color="primary" size="28" class="mr-3" />
       Education
+      <v-spacer />
+      <v-btn
+        v-if="cardOpen"
+        icon="mdi-plus"
+        variant="text"
+        color="primary"
+        size="small"
+        @click.stop="openAdd"
+      />
     </template>
 
     <template #default>
-      <div class="d-flex justify-end mb-2">
-        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-      </div>
 
       <div v-if="store.education.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-school-outline" size="40" class="mb-2" />
@@ -149,6 +155,7 @@ import ConfirmDialog from '../../ConfirmDialog.vue'
 
 const store = useResumeDataStore()
 
+const cardOpen = ref(true)
 const showDialog = ref(false)
 const saving = ref(false)
 const editingId = ref<string | null>(null)

--- a/src/main/webapp/src/components/profile/resume/ExperienceCard.vue
+++ b/src/main/webapp/src/components/profile/resume/ExperienceCard.vue
@@ -1,0 +1,238 @@
+<template>
+  <FormCard collapsible default-open class="mb-4">
+    <template #title>
+      <v-icon icon="mdi-briefcase" color="primary" size="28" class="mr-3" />
+      Experience
+    </template>
+
+    <template #default>
+      <div class="d-flex justify-end mb-2">
+        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
+      </div>
+
+      <div v-if="store.workExperiences.length === 0" class="text-center py-4 text-medium-emphasis">
+        <v-icon icon="mdi-briefcase-outline" size="40" class="mb-2" />
+        <p class="text-body-2">No experience added yet.</p>
+      </div>
+
+      <div v-for="we in store.workExperiences" :key="we.id" class="mb-3 pa-2 rounded">
+        <div class="d-flex align-start mb-1">
+          <v-icon icon="mdi-briefcase-outline" size="small" color="primary" class="mr-2 mt-1" />
+          <div class="flex-grow-1">
+            <div class="text-subtitle-2 font-weight-medium">
+              {{ we.jobTitle || 'Untitled' }}<template v-if="we.company"> &middot; {{ we.company }}</template>
+            </div>
+            <div class="text-caption text-medium-emphasis">
+              <template v-if="we.location">{{ we.location }} &middot; </template>
+              {{ formatDateRange(we) }}
+            </div>
+          </div>
+          <v-tooltip text="Edit" location="top">
+            <template #activator="{ props: tp }">
+              <v-btn v-bind="tp" icon="mdi-pencil" variant="text" size="x-small" color="primary" class="mr-1" @click="openEdit(we)" />
+            </template>
+          </v-tooltip>
+          <v-tooltip text="Delete" location="top">
+            <template #activator="{ props: tp }">
+              <v-btn v-bind="tp" icon="mdi-delete" variant="text" size="x-small" color="error" @click="deleteTarget = we" />
+            </template>
+          </v-tooltip>
+        </div>
+
+        <div v-if="we.id" class="ml-8 mt-2">
+          <BulletEditor
+            :bullets="we.bullets || []"
+            @update:bullets="(b) => onUpdateBullets(we.id!, b)"
+          />
+        </div>
+      </div>
+
+      <FormDialog
+        v-model="showDialog"
+        :title="editingId ? 'Edit Work Experience' : 'Add Work Experience'"
+        icon="mdi-briefcase-plus"
+        :loading="saving"
+        :valid="formValid"
+        @confirm="saveExperience"
+        @cancel="showDialog = false"
+      >
+        <v-row>
+          <v-col cols="12" md="6">
+            <v-text-field
+              v-model="form.jobTitle"
+              label="Job Title"
+              variant="outlined"
+              density="compact"
+              :rules="[rules.required]"
+            />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field
+              v-model="form.company"
+              label="Company"
+              variant="outlined"
+              density="compact"
+              :rules="[rules.required]"
+            />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="form.location" label="Location" variant="outlined" density="compact" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-switch v-model="form.isCurrent" label="I currently work here" color="primary" hide-details />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.startMonth" label="Start Month" type="number" variant="outlined" density="compact" min="1" max="12" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field v-model="form.startYear" label="Start Year" type="number" variant="outlined" density="compact" min="1900" />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field
+              v-model="form.endMonth"
+              label="End Month"
+              type="number"
+              variant="outlined"
+              density="compact"
+              min="1"
+              max="12"
+              :disabled="form.isCurrent"
+            />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field
+              v-model="form.endYear"
+              label="End Year"
+              type="number"
+              variant="outlined"
+              density="compact"
+              min="1900"
+              :disabled="form.isCurrent"
+            />
+          </v-col>
+        </v-row>
+      </FormDialog>
+
+      <ConfirmDialog
+        v-model="deleteConfirm"
+        title="Delete Work Experience"
+        variant="error"
+        confirm-text="Delete"
+        :loading="deleting"
+        @confirm="doDelete"
+      >
+        Are you sure you want to delete "{{ deleteTarget?.jobTitle }}" at {{ deleteTarget?.company }}?
+      </ConfirmDialog>
+    </template>
+  </FormCard>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, computed } from 'vue'
+import type { IWorkExperience, IWorkExperienceBullet } from '../../../models/resume-data.model'
+import { useResumeDataStore } from '../../../stores/resume-data.store'
+import FormCard from '../../forms/FormCard.vue'
+import FormDialog from '../../FormDialog.vue'
+import ConfirmDialog from '../../ConfirmDialog.vue'
+import BulletEditor from './BulletEditor.vue'
+
+const store = useResumeDataStore()
+
+const showDialog = ref(false)
+const saving = ref(false)
+const editingId = ref<string | null>(null)
+const deleteConfirm = ref(false)
+const deleting = ref(false)
+const deleteTarget = ref<IWorkExperience | null>(null)
+
+const form = reactive({
+  jobTitle: '',
+  company: '',
+  location: '',
+  startMonth: undefined as number | undefined,
+  startYear: undefined as number | undefined,
+  endMonth: undefined as number | undefined,
+  endYear: undefined as number | undefined,
+  isCurrent: false,
+})
+
+const rules = {
+  required: (v: string) => !!v || 'This field is required',
+}
+
+const formValid = computed(() => !!form.jobTitle && !!form.company)
+
+function resetForm() {
+  form.jobTitle = ''
+  form.company = ''
+  form.location = ''
+  form.startMonth = undefined
+  form.startYear = undefined
+  form.endMonth = undefined
+  form.endYear = undefined
+  form.isCurrent = false
+}
+
+function openAdd() {
+  editingId.value = null
+  resetForm()
+  showDialog.value = true
+}
+
+function openEdit(we: IWorkExperience) {
+  editingId.value = we.id || null
+  form.jobTitle = we.jobTitle || ''
+  form.company = we.company || ''
+  form.location = we.location || ''
+  form.startMonth = we.startMonth ?? undefined
+  form.startYear = we.startYear ?? undefined
+  form.endMonth = we.endMonth ?? undefined
+  form.endYear = we.endYear ?? undefined
+  form.isCurrent = we.isCurrent ?? false
+  showDialog.value = true
+}
+
+function formatDateRange(we: IWorkExperience): string {
+  const start = formatDatePart(we.startMonth, we.startYear)
+  const end = we.isCurrent ? 'Present' : formatDatePart(we.endMonth, we.endYear)
+  if (!start && !end) return ''
+  return `${start || '?'} — ${end || '?'}`
+}
+
+function formatDatePart(month?: number | null, year?: number | null): string {
+  if (month && year) return `${month.toString().padStart(2, '0')}/${year}`
+  if (year) return String(year)
+  return ''
+}
+
+async function saveExperience() {
+  saving.value = true
+  try {
+    const dto: IWorkExperience = { ...form }
+    if (editingId.value) {
+      await store.updateWorkExperience(editingId.value, dto)
+    } else {
+      await store.createWorkExperience(dto)
+    }
+    showDialog.value = false
+  } finally {
+    saving.value = false
+  }
+}
+
+async function doDelete() {
+  if (!deleteTarget.value?.id) return
+  deleting.value = true
+  try {
+    await store.deleteWorkExperience(deleteTarget.value.id)
+    deleteConfirm.value = false
+    deleteTarget.value = null
+  } finally {
+    deleting.value = false
+  }
+}
+
+async function onUpdateBullets(workExperienceId: string, bullets: IWorkExperienceBullet[]) {
+  await store.replaceBullets(workExperienceId, bullets)
+}
+</script>

--- a/src/main/webapp/src/components/profile/resume/ExperienceCard.vue
+++ b/src/main/webapp/src/components/profile/resume/ExperienceCard.vue
@@ -67,7 +67,7 @@
                 variant="text"
                 size="x-small"
                 color="error"
-                @click="deleteTarget = we"
+                @click="deleteTarget = we; deleteConfirm = true"
               />
             </template>
           </v-tooltip>

--- a/src/main/webapp/src/components/profile/resume/ExperienceCard.vue
+++ b/src/main/webapp/src/components/profile/resume/ExperienceCard.vue
@@ -25,21 +25,50 @@
           <v-icon icon="mdi-briefcase-outline" size="small" color="primary" class="mr-2 mt-1" />
           <div class="flex-grow-1">
             <div class="text-subtitle-2 font-weight-medium">
-              {{ we.jobTitle || 'Untitled' }}<template v-if="we.company"> &middot; {{ we.company }}</template>
+              {{ we.jobTitle || 'Untitled'
+              }}<template v-if="we.company"> &middot; {{ we.company }}</template>
             </div>
             <div class="text-caption text-medium-emphasis">
               <template v-if="we.location">{{ we.location }} &middot; </template>
               {{ formatDateRange(we) }}
             </div>
           </div>
+          <v-tooltip text="Add bullet" location="top">
+            <template #activator="{ props: tp }">
+              <v-btn
+                v-bind="tp"
+                icon="mdi-plus-circle-outline"
+                variant="text"
+                size="x-small"
+                color="primary"
+                class="mr-1"
+                @click="openAddBullet(we)"
+              />
+            </template>
+          </v-tooltip>
           <v-tooltip text="Edit" location="top">
             <template #activator="{ props: tp }">
-              <v-btn v-bind="tp" icon="mdi-pencil" variant="text" size="x-small" color="primary" class="mr-1" @click="openEdit(we)" />
+              <v-btn
+                v-bind="tp"
+                icon="mdi-pencil"
+                variant="text"
+                size="x-small"
+                color="primary"
+                class="mr-1"
+                @click="openEdit(we)"
+              />
             </template>
           </v-tooltip>
           <v-tooltip text="Delete" location="top">
             <template #activator="{ props: tp }">
-              <v-btn v-bind="tp" icon="mdi-delete" variant="text" size="x-small" color="error" @click="deleteTarget = we" />
+              <v-btn
+                v-bind="tp"
+                icon="mdi-delete"
+                variant="text"
+                size="x-small"
+                color="error"
+                @click="deleteTarget = we"
+              />
             </template>
           </v-tooltip>
         </div>
@@ -81,16 +110,41 @@
             />
           </v-col>
           <v-col cols="12" md="6">
-            <v-text-field v-model="form.location" label="Location" variant="outlined" density="compact" />
+            <v-text-field
+              v-model="form.location"
+              label="Location"
+              variant="outlined"
+              density="compact"
+            />
           </v-col>
           <v-col cols="12" md="6">
-            <v-switch v-model="form.isCurrent" label="I currently work here" color="primary" hide-details />
+            <v-switch
+              v-model="form.isCurrent"
+              label="I currently work here"
+              color="primary"
+              hide-details
+            />
           </v-col>
           <v-col cols="6" md="3">
-            <v-text-field v-model="form.startMonth" label="Start Month" type="number" variant="outlined" density="compact" min="1" max="12" />
+            <v-text-field
+              v-model="form.startMonth"
+              label="Start Month"
+              type="number"
+              variant="outlined"
+              density="compact"
+              min="1"
+              max="12"
+            />
           </v-col>
           <v-col cols="6" md="3">
-            <v-text-field v-model="form.startYear" label="Start Year" type="number" variant="outlined" density="compact" min="1900" />
+            <v-text-field
+              v-model="form.startYear"
+              label="Start Year"
+              type="number"
+              variant="outlined"
+              density="compact"
+              min="1900"
+            />
           </v-col>
           <v-col cols="6" md="3">
             <v-text-field
@@ -118,6 +172,27 @@
         </v-row>
       </FormDialog>
 
+      <FormDialog
+        v-model="showBulletDialog"
+        title="Add Bullet Point"
+        icon="mdi-plus-circle-outline"
+        :loading="savingBullet"
+        :valid="!!bulletText"
+        @confirm="saveBullet"
+        @cancel="showBulletDialog = false"
+      >
+        <v-textarea
+          v-model="bulletText"
+          label="Bullet point"
+          variant="outlined"
+          density="compact"
+          rows="3"
+          placeholder="Describe an accomplishment or responsibility..."
+          :rules="[rules.required]"
+          hide-details
+        />
+      </FormDialog>
+
       <ConfirmDialog
         v-model="deleteConfirm"
         title="Delete Work Experience"
@@ -126,7 +201,8 @@
         :loading="deleting"
         @confirm="doDelete"
       >
-        Are you sure you want to delete "{{ deleteTarget?.jobTitle }}" at {{ deleteTarget?.company }}?
+        Are you sure you want to delete "{{ deleteTarget?.jobTitle }}" at
+        {{ deleteTarget?.company }}?
       </ConfirmDialog>
     </template>
   </FormCard>
@@ -150,6 +226,10 @@ const editingId = ref<string | null>(null)
 const deleteConfirm = ref(false)
 const deleting = ref(false)
 const deleteTarget = ref<IWorkExperience | null>(null)
+const showBulletDialog = ref(false)
+const savingBullet = ref(false)
+const bulletText = ref('')
+const bulletTarget = ref<IWorkExperience | null>(null)
 
 const form = reactive({
   jobTitle: '',
@@ -240,5 +320,28 @@ async function doDelete() {
 
 async function onUpdateBullets(workExperienceId: string, bullets: IWorkExperienceBullet[]) {
   await store.replaceBullets(workExperienceId, bullets)
+}
+
+function openAddBullet(we: IWorkExperience) {
+  bulletTarget.value = we
+  bulletText.value = ''
+  showBulletDialog.value = true
+}
+
+async function saveBullet() {
+  if (!bulletTarget.value?.id || !bulletText.value.trim()) return
+  savingBullet.value = true
+  try {
+    const current = bulletTarget.value.bullets ?? []
+    const newBullet: IWorkExperienceBullet = {
+      content: bulletText.value.trim(),
+      displayOrder: current.length,
+    }
+    await store.replaceBullets(bulletTarget.value.id, [...current, newBullet])
+    showBulletDialog.value = false
+    bulletTarget.value = null
+  } finally {
+    savingBullet.value = false
+  }
 }
 </script>

--- a/src/main/webapp/src/components/profile/resume/ExperienceCard.vue
+++ b/src/main/webapp/src/components/profile/resume/ExperienceCard.vue
@@ -1,15 +1,20 @@
 <template>
-  <FormCard collapsible default-open class="mb-4">
+  <FormCard v-model="cardOpen" collapsible default-open class="mb-4">
     <template #title>
       <v-icon icon="mdi-briefcase" color="primary" size="28" class="mr-3" />
       Experience
+      <v-spacer />
+      <v-btn
+        v-if="cardOpen"
+        icon="mdi-plus"
+        variant="text"
+        color="primary"
+        size="small"
+        @click.stop="openAdd"
+      />
     </template>
 
     <template #default>
-      <div class="d-flex justify-end mb-2">
-        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-      </div>
-
       <div v-if="store.workExperiences.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-briefcase-outline" size="40" class="mb-2" />
         <p class="text-body-2">No experience added yet.</p>
@@ -138,6 +143,7 @@ import BulletEditor from './BulletEditor.vue'
 
 const store = useResumeDataStore()
 
+const cardOpen = ref(true)
 const showDialog = ref(false)
 const saving = ref(false)
 const editingId = ref<string | null>(null)

--- a/src/main/webapp/src/components/profile/resume/LanguageCard.vue
+++ b/src/main/webapp/src/components/profile/resume/LanguageCard.vue
@@ -1,14 +1,20 @@
 <template>
-  <FormCard collapsible default-open class="mb-4">
+  <FormCard v-model="cardOpen" collapsible default-open class="mb-4">
     <template #title>
       <v-icon icon="mdi-translate" color="primary" size="28" class="mr-3" />
       Languages
+      <v-spacer />
+      <v-btn
+        v-if="cardOpen"
+        icon="mdi-plus"
+        variant="text"
+        color="primary"
+        size="small"
+        @click.stop="openAdd"
+      />
     </template>
 
     <template #default>
-      <div class="d-flex justify-end mb-2">
-        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-      </div>
       <div v-if="store.languages.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-translate" size="40" class="mb-2" />
         <p class="text-body-2">No languages added yet.</p>
@@ -83,6 +89,8 @@ import FormDialog from '../../FormDialog.vue'
 import ConfirmDialog from '../../ConfirmDialog.vue'
 
 const store = useResumeDataStore()
+
+const cardOpen = ref(true)
 
 const proficiencyItems = [
   { title: 'Native', value: 'NATIVE' },

--- a/src/main/webapp/src/components/profile/resume/ProjectCard.vue
+++ b/src/main/webapp/src/components/profile/resume/ProjectCard.vue
@@ -1,14 +1,20 @@
 <template>
-  <FormCard collapsible default-open class="mb-4">
+  <FormCard v-model="cardOpen" collapsible default-open class="mb-4">
     <template #title>
       <v-icon icon="mdi-code-braces" color="primary" size="28" class="mr-3" />
       Projects
+      <v-spacer />
+      <v-btn
+        v-if="cardOpen"
+        icon="mdi-plus"
+        variant="text"
+        color="primary"
+        size="small"
+        @click.stop="openAdd"
+      />
     </template>
 
     <template #default>
-      <div class="d-flex justify-end mb-2">
-        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-      </div>
       <div v-if="store.projects.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-code-braces" size="40" class="mb-2" />
         <p class="text-body-2">No projects added yet.</p>
@@ -118,6 +124,7 @@ import ConfirmDialog from '../../ConfirmDialog.vue'
 
 const store = useResumeDataStore()
 
+const cardOpen = ref(true)
 const showDialog = ref(false)
 const saving = ref(false)
 const editingId = ref<string | null>(null)

--- a/src/main/webapp/src/components/profile/resume/PublicationCard.vue
+++ b/src/main/webapp/src/components/profile/resume/PublicationCard.vue
@@ -1,14 +1,20 @@
 <template>
-  <FormCard collapsible default-open class="mb-4">
+  <FormCard v-model="cardOpen" collapsible default-open class="mb-4">
     <template #title>
       <v-icon icon="mdi-book-open-page-variant" color="primary" size="28" class="mr-3" />
       Publications
+      <v-spacer />
+      <v-btn
+        v-if="cardOpen"
+        icon="mdi-plus"
+        variant="text"
+        color="primary"
+        size="small"
+        @click.stop="openAdd"
+      />
     </template>
 
     <template #default>
-      <div class="d-flex justify-end mb-2">
-        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-      </div>
       <div v-if="store.publications.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-book-open-page-variant-outline" size="40" class="mb-2" />
         <p class="text-body-2">No publications added yet.</p>
@@ -88,6 +94,7 @@ import ConfirmDialog from '../../ConfirmDialog.vue'
 
 const store = useResumeDataStore()
 
+const cardOpen = ref(true)
 const showDialog = ref(false)
 const saving = ref(false)
 const editingId = ref<string | null>(null)

--- a/src/main/webapp/src/components/profile/resume/ResumeTab.vue
+++ b/src/main/webapp/src/components/profile/resume/ResumeTab.vue
@@ -76,7 +76,7 @@ import ExtractionPreviewDialog from './ExtractionPreviewDialog.vue'
 import type { IResumeExtractionResult } from '../../../models/resume-data.model'
 
 const props = defineProps<{
-  profile: IProfile
+  profile: IProfile | null
 }>()
 
 const emit = defineEmits<{

--- a/src/main/webapp/src/components/profile/resume/ResumeTab.vue
+++ b/src/main/webapp/src/components/profile/resume/ResumeTab.vue
@@ -8,9 +8,7 @@
       @extract="onExtract"
     />
     <SkillsCard />
-    <div v-for="we in store.workExperiences" :key="we.id">
-      <WorkExperienceCard :work-experience="we" />
-    </div>
+    <ExperienceCard />
     <EducationCard />
 
     <ProjectCard />
@@ -20,55 +18,6 @@
     <PublicationCard />
     <AwardCard />
     <AffiliationCard />
-
-    <FormDialog
-      v-model="showAddWorkExperience"
-      title="Add Work Experience"
-      icon="mdi-briefcase-plus"
-      :loading="savingNew"
-      :valid="workFormValid"
-      @confirm="saveNewWorkExperience"
-      @cancel="showAddWorkExperience = false"
-    >
-      <v-row>
-        <v-col cols="12" md="6">
-          <v-text-field
-            v-model="workForm.jobTitle"
-            label="Job Title"
-            variant="outlined"
-            density="compact"
-            :rules="[rules.required]"
-          />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field
-            v-model="workForm.company"
-            label="Company"
-            variant="outlined"
-            density="compact"
-            :rules="[rules.required]"
-          />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model="workForm.location" label="Location" variant="outlined" density="compact" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-switch v-model="workForm.isCurrent" label="I currently work here" color="primary" hide-details />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="workForm.startMonth" label="Start Month" type="number" variant="outlined" density="compact" min="1" max="12" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="workForm.startYear" label="Start Year" type="number" variant="outlined" density="compact" min="1900" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="workForm.endMonth" label="End Month" type="number" variant="outlined" density="compact" min="1" max="12" :disabled="workForm.isCurrent" />
-        </v-col>
-        <v-col cols="6" md="3">
-          <v-text-field v-model="workForm.endYear" label="End Year" type="number" variant="outlined" density="compact" min="1900" :disabled="workForm.isCurrent" />
-        </v-col>
-      </v-row>
-    </FormDialog>
 
     <Teleport to="body">
       <v-menu>
@@ -109,12 +58,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import type { IProfile } from '../../../models'
 import { useResumeDataStore } from '../../../stores/resume-data.store'
 import ResumeFileCard from './ResumeFileCard.vue'
 import SkillsCard from './SkillsCard.vue'
-import WorkExperienceCard from './WorkExperienceCard.vue'
+import ExperienceCard from './ExperienceCard.vue'
 import EducationCard from './EducationCard.vue'
 import ProjectCard from './ProjectCard.vue'
 import CertificationCard from './CertificationCard.vue'
@@ -124,8 +73,7 @@ import PublicationCard from './PublicationCard.vue'
 import AwardCard from './AwardCard.vue'
 import AffiliationCard from './AffiliationCard.vue'
 import ExtractionPreviewDialog from './ExtractionPreviewDialog.vue'
-import FormDialog from '../../FormDialog.vue'
-import type { IResumeExtractionResult, IWorkExperience } from '../../../models/resume-data.model'
+import type { IResumeExtractionResult } from '../../../models/resume-data.model'
 
 const props = defineProps<{
   profile: IProfile
@@ -139,38 +87,6 @@ const emit = defineEmits<{
 const store = useResumeDataStore()
 const showPreview = ref(false)
 const savingExtracted = ref(false)
-const showAddWorkExperience = ref(false)
-const savingNew = ref(false)
-
-const workForm = reactive({
-  jobTitle: '',
-  company: '',
-  location: '',
-  startMonth: undefined as number | undefined,
-  startYear: undefined as number | undefined,
-  endMonth: undefined as number | undefined,
-  endYear: undefined as number | undefined,
-  isCurrent: false,
-})
-
-const rules = {
-  required: (v: string) => !!v || 'This field is required',
-}
-
-const workFormValid = computed(() => !!workForm.jobTitle && !!workForm.company)
-
-watch(showAddWorkExperience, (open) => {
-  if (open) {
-    workForm.jobTitle = ''
-    workForm.company = ''
-    workForm.location = ''
-    workForm.startMonth = undefined
-    workForm.startYear = undefined
-    workForm.endMonth = undefined
-    workForm.endYear = undefined
-    workForm.isCurrent = false
-  }
-})
 
 interface AddableSection {
   key: string
@@ -180,7 +96,6 @@ interface AddableSection {
 
 const addableSections = computed<AddableSection[]>(() => {
   const sections: AddableSection[] = []
-    sections.push({ key: 'work-experience', label: 'Work Experience', icon: 'mdi-briefcase' })
   if (!store.education || store.education.length === 0) sections.push({ key: 'education', label: 'Education', icon: 'mdi-school' })
   if (!store.projects || store.projects.length === 0) sections.push({ key: 'projects', label: 'Projects', icon: 'mdi-code-braces' })
   if (!store.certifications || store.certifications.length === 0) sections.push({ key: 'certifications', label: 'Certifications', icon: 'mdi-certificate' })
@@ -221,25 +136,10 @@ function onResumeIdUpdate(value: string | undefined) {
 }
 
 function onAddSection(sectionKey: string) {
-  if (sectionKey === 'work-experience') {
-    showAddWorkExperience.value = true
-    return
-  }
   if (sectionKey === 'education') {
     return
   }
   showPreview.value = false
-}
-
-async function saveNewWorkExperience() {
-  savingNew.value = true
-  try {
-    const dto: IWorkExperience = { ...workForm }
-    await store.createWorkExperience(dto)
-    showAddWorkExperience.value = false
-  } finally {
-    savingNew.value = false
-  }
 }
 </script>
 

--- a/src/main/webapp/src/components/profile/resume/SkillsCard.vue
+++ b/src/main/webapp/src/components/profile/resume/SkillsCard.vue
@@ -1,14 +1,20 @@
 <template>
-  <FormCard collapsible default-open class="mb-4">
+  <FormCard v-model="cardOpen" collapsible default-open class="mb-4">
     <template #title>
       <v-icon icon="mdi-lightning-bolt" color="primary" size="28" class="mr-3" />
       Skills
+      <v-spacer />
+      <v-btn
+        v-if="cardOpen"
+        icon="mdi-plus"
+        variant="text"
+        color="primary"
+        size="small"
+        @click.stop="showAddForm = true"
+      />
     </template>
 
     <template #default>
-      <div class="d-flex justify-end mb-2">
-        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="showAddForm = true" />
-      </div>
       <div v-if="skillGroups.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-lightning-bolt-outline" size="40" class="mb-2" />
         <p class="text-body-2">No skills added yet. Extract from your resume or add manually.</p>
@@ -92,6 +98,7 @@ import FormDialog from '../../FormDialog.vue'
 const store = useResumeDataStore()
 const skillGroups = computed(() => store.skillGroups)
 
+const cardOpen = ref(true)
 const showFormDialog = ref(false)
 const saving = ref(false)
 const editingId = ref<string | null>(null)

--- a/src/main/webapp/src/components/profile/resume/VolunteerCard.vue
+++ b/src/main/webapp/src/components/profile/resume/VolunteerCard.vue
@@ -1,14 +1,20 @@
 <template>
-  <FormCard collapsible default-open class="mb-4">
+  <FormCard v-model="cardOpen" collapsible default-open class="mb-4">
     <template #title>
       <v-icon icon="mdi-hand-heart" color="primary" size="28" class="mr-3" />
       Volunteer Work
+      <v-spacer />
+      <v-btn
+        v-if="cardOpen"
+        icon="mdi-plus"
+        variant="text"
+        color="primary"
+        size="small"
+        @click.stop="openAdd"
+      />
     </template>
 
     <template #default>
-      <div class="d-flex justify-end mb-2">
-        <v-btn icon="mdi-plus" variant="text" color="primary" size="small" @click="openAdd" />
-      </div>
       <div v-if="store.volunteerWork.length === 0" class="text-center py-4 text-medium-emphasis">
         <v-icon icon="mdi-hand-heart-outline" size="40" class="mb-2" />
         <p class="text-body-2">No volunteer work added yet.</p>
@@ -103,6 +109,7 @@ import ConfirmDialog from '../../ConfirmDialog.vue'
 
 const store = useResumeDataStore()
 
+const cardOpen = ref(true)
 const showDialog = ref(false)
 const saving = ref(false)
 const editingId = ref<string | null>(null)

--- a/src/main/webapp/src/stores/resume-data.store.ts
+++ b/src/main/webapp/src/stores/resume-data.store.ts
@@ -27,7 +27,15 @@ export const useResumeDataStore = defineStore('resumeData', () => {
   const extracting = ref(false)
   const extractionResult = ref<IResumeExtractionResult | null>(null)
 
-  const workExperiences = computed(() => aggregate.value.workExperiences ?? [])
+  const workExperiences = computed(() => {
+    const list = aggregate.value.workExperiences ?? []
+    return [...list].sort((a, b) => {
+      const aYear = a.startYear ?? 0
+      const bYear = b.startYear ?? 0
+      if (bYear !== aYear) return bYear - aYear
+      return (b.startMonth ?? 0) - (a.startMonth ?? 0)
+    })
+  })
   const education = computed(() => aggregate.value.education ?? [])
   const skillGroups = computed(() => aggregate.value.skillGroups ?? [])
   const projects = computed(() => aggregate.value.projects ?? [])


### PR DESCRIPTION
- Group work experiences under a single "Experience" FormCard
- Move add (+) buttons to FormCard title slots (collapse-aware visibility)
- Add v-model support to FormCard for open/close state tracking
- Rework bullet points: dialog-based add, inline X delete
- Sort work experiences by start date descending